### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Run Tests
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/haakonhelmenrusas/Bueboka/security/code-scanning/1](https://github.com/haakonhelmenrusas/Bueboka/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since this workflow only checks out the repository, sets up Node.js, installs dependencies, and runs tests, it only requires read access to the repository contents. We will add `permissions: contents: read` at the root level of the workflow to apply this minimal permission to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
