### PR TITLE
feat(i18n): translate intro and auth screens

### DIFF
--- a/app/auth.tsx
+++ b/app/auth.tsx
@@ -3,6 +3,7 @@ import { Keyboard, KeyboardAvoidingView, Platform, ScrollView } from 'react-nati
 import { useRouter } from 'expo-router';
 import { Button, Message } from '@/components/common';
 import { useAuth } from '@/hooks';
+import { useTranslation } from '@/contexts';
 import { AppError } from '@/services';
 import { AuthLogo, AuthForm, SocialLogin, AuthToggle, LoadingOverlay, EmailVerification } from '@/components/auth';
 import { styles } from '@/components/auth/AuthStyles';
@@ -13,6 +14,7 @@ interface AuthScreenProps {
 
 function AuthScreen({ onAuthSuccess }: AuthScreenProps) {
   const { login, register, loginWithGoogle, isLoading, isAuthenticated, error, clearError } = useAuth();
+  const { t } = useTranslation();
   const router = useRouter();
   const [isLogin, setIsLogin] = useState(false);
   const [email, setEmail] = useState('');
@@ -37,7 +39,7 @@ function AuthScreen({ onAuthSuccess }: AuthScreenProps) {
     if (error instanceof AppError) {
       setLocalError(error.message);
     } else {
-      setLocalError(error?.message || 'An error occurred');
+      setLocalError(error?.message || t['validation.genericError']);
     }
   };
 
@@ -46,7 +48,7 @@ function AuthScreen({ onAuthSuccess }: AuthScreenProps) {
     clearError();
 
     if (!email || !password) {
-      setLocalError('Email and password are required');
+      setLocalError(t['validation.emailPasswordRequired']);
       return;
     }
 
@@ -65,12 +67,12 @@ function AuthScreen({ onAuthSuccess }: AuthScreenProps) {
     clearError();
 
     if (!email || !password) {
-      setLocalError('E-post og passord er påkrevd');
+      setLocalError(t['validation.emailPasswordRequired']);
       return;
     }
 
     if (password.length < 8) {
-      setLocalError('Passordet må være minst 8 tegn');
+      setLocalError(t['validation.passwordMinLength']);
       return;
     }
 
@@ -134,14 +136,14 @@ function AuthScreen({ onAuthSuccess }: AuthScreenProps) {
         />
         <Button
           buttonStyle={{ marginTop: 8 }}
-          label={isLoading ? 'Venter...' : isLogin ? 'Logg inn' : 'Opprett konto'}
+          label={isLoading ? t['common.loading'] : isLogin ? t['auth.loginButton'] : t['auth.registerButton']}
           onPress={handleSubmit}
           disabled={isLoading}
           variant="tertiary"
         />
         {(localError || error) && (
           <Message
-            title="Feil"
+            title={t['auth.errorTitle']}
             description={localError || error || ''}
             onPress={() => {
               setLocalError(null);

--- a/app/intro.tsx
+++ b/app/intro.tsx
@@ -6,12 +6,14 @@ import { useRouter } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Button } from '@/components/common';
 import { colors } from '@/styles/colors';
+import { useTranslation } from '@/contexts';
 import { styles } from '@/components/intro/IntroStyles';
 
 export const INTRO_SEEN_KEY = 'bueboka_has_seen_intro';
 
 export default function IntroScreen() {
   const router = useRouter();
+  const { t } = useTranslation();
 
   const markSeenAndNavigate = async () => {
     await AsyncStorage.setItem(INTRO_SEEN_KEY, 'true');
@@ -38,20 +40,24 @@ export default function IntroScreen() {
 
           {/* Hero copy */}
           <View style={styles.heroSection}>
-            <Text style={styles.tagline}>Treningsporing for bueskyttere</Text>
+            <Text style={styles.tagline}>{t['intro.tagline']}</Text>
             <Text style={styles.title}>
-              {'Hvert skudd\n'}
-              <Text style={styles.titleAccent}>teller.</Text>
+              {t['intro.titleLine1']}
+              {'\n'}
+              <Text style={styles.titleAccent}>{t['intro.titleLine2']}</Text>
             </Text>
-            <Text style={styles.body}>
-              Logg treninger og konkurranser, spor siktmerkene dine og følg fremgangen over tid. Alt du trenger for å bli en bedre
-              bueskytter.
-            </Text>
+            <Text style={styles.body}>{t['intro.body']}</Text>
           </View>
 
           {/* CTA */}
           <View style={styles.ctaSection}>
-            <Button label="Kom i gang" onPress={markSeenAndNavigate} variant="tertiary" width="100%" buttonStyle={styles.ctaButton} />
+            <Button
+              label={t['intro.getStarted']}
+              onPress={markSeenAndNavigate}
+              variant="tertiary"
+              width="100%"
+              buttonStyle={styles.ctaButton}
+            />
           </View>
         </View>
       </SafeAreaView>

--- a/components/auth/AuthForm.tsx
+++ b/components/auth/AuthForm.tsx
@@ -1,5 +1,6 @@
 import { View } from 'react-native';
 import { Input } from '@/components/common';
+import { useTranslation } from '@/contexts';
 import { styles } from './AuthStyles';
 
 interface AuthFormProps {
@@ -11,10 +12,11 @@ interface AuthFormProps {
 }
 
 export default function AuthForm({ email, password, isLoading, onEmailChange, onPasswordChange }: AuthFormProps) {
+  const { t } = useTranslation();
   return (
     <View style={styles.form}>
       <Input
-        label="E-post"
+        label={t['auth.emailLabel']}
         value={email}
         onChangeText={onEmailChange}
         keyboardType="email-address"
@@ -23,7 +25,7 @@ export default function AuthForm({ email, password, isLoading, onEmailChange, on
         labelStyle={styles.whiteLabel}
       />
       <Input
-        label="Passord"
+        label={t['auth.passwordLabel']}
         value={password}
         onChangeText={onPasswordChange}
         secureTextEntry

--- a/components/auth/AuthToggle.tsx
+++ b/components/auth/AuthToggle.tsx
@@ -1,4 +1,5 @@
 import { View, Text, TouchableOpacity } from 'react-native';
+import { useTranslation } from '@/contexts';
 import { styles } from './AuthStyles';
 
 interface AuthToggleProps {
@@ -8,10 +9,11 @@ interface AuthToggleProps {
 }
 
 export default function AuthToggle({ isLogin, isLoading, onToggle }: AuthToggleProps) {
+  const { t } = useTranslation();
   return (
     <View style={styles.toggleContainer}>
       <TouchableOpacity onPress={onToggle} disabled={isLoading}>
-        <Text style={styles.toggleLink}>{isLogin ? 'Registrer deg' : 'Logg inn'}</Text>
+        <Text style={styles.toggleLink}>{isLogin ? t['auth.toggleToRegister'] : t['auth.toggleToLogin']}</Text>
       </TouchableOpacity>
     </View>
   );

--- a/components/auth/EmailVerification.tsx
+++ b/components/auth/EmailVerification.tsx
@@ -3,6 +3,7 @@ import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
 import { colors } from '@/styles/colors';
 import { Button, Message } from '@/components/common';
 import { useAuth } from '@/hooks';
+import { useTranslation } from '@/contexts';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faEnvelope } from '@fortawesome/free-solid-svg-icons';
 
@@ -13,6 +14,7 @@ interface EmailVerificationProps {
 
 export default function EmailVerification({ email, onVerified }: EmailVerificationProps) {
   const { resendVerificationEmail, refreshUser, user, isLoading } = useAuth();
+  const { t } = useTranslation();
   const [resending, setResending] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [cooldown, setCooldown] = useState(0);
@@ -24,7 +26,7 @@ export default function EmailVerification({ email, onVerified }: EmailVerificati
       setResending(true);
       setMessage(null);
       await resendVerificationEmail();
-      setMessage({ type: 'success', text: 'Verification email sent! Check your inbox.' });
+      setMessage({ type: 'success', text: t['emailVerification.sentSuccess'] });
 
       // Start cooldown
       setCooldown(60);
@@ -38,7 +40,7 @@ export default function EmailVerification({ email, onVerified }: EmailVerificati
         });
       }, 1000);
     } catch (error: any) {
-      setMessage({ type: 'error', text: error.message || 'Failed to resend email' });
+      setMessage({ type: 'error', text: error.message || t['emailVerification.sendFailed'] });
     } finally {
       setResending(false);
     }
@@ -50,10 +52,10 @@ export default function EmailVerification({ email, onVerified }: EmailVerificati
       if (user?.emailVerified) {
         onVerified?.();
       } else {
-        setMessage({ type: 'error', text: 'Email not verified yet. Please check your inbox.' });
+        setMessage({ type: 'error', text: t['emailVerification.notVerifiedYet'] });
       }
-    } catch (error: any) {
-      setMessage({ type: 'error', text: 'Failed to check verification status' });
+    } catch {
+      setMessage({ type: 'error', text: t['emailVerification.checkFailed'] });
     }
   };
 
@@ -63,24 +65,30 @@ export default function EmailVerification({ email, onVerified }: EmailVerificati
         <FontAwesomeIcon icon={faEnvelope} size={64} color={colors.primary} />
       </View>
 
-      <Text style={styles.title}>Bekreft e-postadressen din</Text>
+      <Text style={styles.title}>{t['emailVerification.title']}</Text>
       <Text style={styles.description}>
-        Vi har sendt en bekreftelseslenke til <Text style={styles.email}>{email}</Text>
+        {t['emailVerification.sentTo']} <Text style={styles.email}>{email}</Text>
       </Text>
-      <Text style={styles.instructions}>
-        Klikk på lenken i e-posten for å bekrefte kontoen din. Når du har bekreftet, kan du komme tilbake hit og trykke på "Jeg har
-        bekreftet".
-      </Text>
+      <Text style={styles.instructions}>{t['emailVerification.instructions']}</Text>
 
       {message && (
-        <Message title={message.type === 'success' ? 'Suksess' : 'Feil'} description={message.text} onPress={() => setMessage(null)} />
+        <Message
+          title={message.type === 'success' ? t['common.success'] : t['common.error']}
+          description={message.text}
+          onPress={() => setMessage(null)}
+        />
       )}
 
       <View style={styles.buttonsContainer}>
-        <Button label="Jeg har bekreftet" onPress={handleCheckVerification} disabled={isLoading} buttonStyle={styles.primaryButton} />
+        <Button
+          label={t['emailVerification.checkButton']}
+          onPress={handleCheckVerification}
+          disabled={isLoading}
+          buttonStyle={styles.primaryButton}
+        />
 
         <Button
-          label={cooldown > 0 ? `Send på nytt (${cooldown}s)` : 'Send e-post på nytt'}
+          label={cooldown > 0 ? `${t['emailVerification.resendCooldown']} (${cooldown}s)` : t['emailVerification.resendButton']}
           onPress={handleResendEmail}
           disabled={resending || isLoading || cooldown > 0}
           variant="standard"
@@ -91,11 +99,11 @@ export default function EmailVerification({ email, onVerified }: EmailVerificati
       {(isLoading || resending) && (
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="small" color={colors.primary} />
-          <Text style={styles.loadingText}>{resending ? 'Sender e-post...' : 'Sjekker status...'}</Text>
+          <Text style={styles.loadingText}>{resending ? t['emailVerification.sendingEmail'] : t['emailVerification.checkingStatus']}</Text>
         </View>
       )}
 
-      <Text style={styles.helpText}>Fikk du ikke e-posten? Sjekk søppelpostmappen din eller klikk "Send e-post på nytt".</Text>
+      <Text style={styles.helpText}>{t['emailVerification.helpText']}</Text>
     </View>
   );
 }

--- a/components/auth/EmailVerificationBanner.tsx
+++ b/components/auth/EmailVerificationBanner.tsx
@@ -2,11 +2,13 @@ import React, { useState } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { colors } from '@/styles/colors';
 import { useAuth } from '@/hooks';
+import { useTranslation } from '@/contexts';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faExclamationCircle, faTimes } from '@fortawesome/free-solid-svg-icons';
 
 export default function EmailVerificationBanner() {
   const { user, resendVerificationEmail } = useAuth();
+  const { t } = useTranslation();
   const [dismissed, setDismissed] = useState(false);
   const [sending, setSending] = useState(false);
 
@@ -19,10 +21,10 @@ export default function EmailVerificationBanner() {
     try {
       setSending(true);
       await resendVerificationEmail();
-      alert('Verification email sent! Check your inbox.');
+      alert(t['emailVerification.sentSuccess']);
     } catch (error: any) {
       console.error('Resend verification email error:', error);
-      const errorMessage = error?.message || error?.response?.data?.message || 'Failed to send verification email. Please try again.';
+      const errorMessage = error?.message || error?.response?.data?.message || t['emailBanner.sendError'];
       alert(errorMessage);
     } finally {
       setSending(false);
@@ -34,9 +36,9 @@ export default function EmailVerificationBanner() {
       <View style={styles.content}>
         <FontAwesomeIcon icon={faExclamationCircle} size={18} color={colors.white} style={styles.icon} />
         <View style={styles.textContainer}>
-          <Text style={styles.text}>E-posten din er ikke bekreftet.</Text>
+          <Text style={styles.text}>{t['emailBanner.notVerified']}</Text>
           <TouchableOpacity onPress={handleResend} disabled={sending}>
-            <Text style={styles.link}>{sending ? 'Sender...' : 'Send bekreftelse på nytt'}</Text>
+            <Text style={styles.link}>{sending ? t['emailBanner.sending'] : t['emailBanner.resend']}</Text>
           </TouchableOpacity>
         </View>
       </View>

--- a/components/auth/SocialLogin.tsx
+++ b/components/auth/SocialLogin.tsx
@@ -1,6 +1,7 @@
 import { View, Text } from 'react-native';
 import { Button } from '@/components/common';
 import { GoogleLogo } from '@/components/common/GoogleLogo/GoogleLogo';
+import { useTranslation } from '@/contexts';
 import { styles } from './AuthStyles';
 
 interface SocialLoginProps {
@@ -9,16 +10,17 @@ interface SocialLoginProps {
 }
 
 export default function SocialLogin({ isLoading, onGoogleLogin }: SocialLoginProps) {
+  const { t } = useTranslation();
   return (
     <>
       <View style={styles.dividerContainer}>
         <View style={styles.divider} />
-        <Text style={styles.dividerText}>eller</Text>
+        <Text style={styles.dividerText}>{t['auth.divider']}</Text>
         <View style={styles.divider} />
       </View>
       <View style={styles.socialButtonsContainer}>
         <Button
-          label="Fortsett med Google"
+          label={t['auth.loginWithGoogle']}
           onPress={onGoogleLogin}
           disabled={isLoading}
           variant="tertiary"

--- a/contexts/__tests__/LanguageContext.test.tsx
+++ b/contexts/__tests__/LanguageContext.test.tsx
@@ -1,12 +1,18 @@
-import React from 'react';
-import { Text } from 'react-native';
-import { act, render, waitFor } from '@testing-library/react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { LanguageProvider, useTranslation } from '@/contexts/LanguageContext';
+// jestSetup.ts ships a default mock for @/contexts/LanguageContext so other
+// components can render without a real provider. This test needs the real
+// implementation to verify the provider's behavior.
+jest.unmock('@/contexts/LanguageContext');
 
 jest.mock('expo-localization', () => ({
   getLocales: jest.fn(() => [{ languageCode: 'en' }]),
 }));
+
+import React from 'react';
+import { Text } from 'react-native';
+import { act, render, waitFor } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+// eslint-disable-next-line import/first
+import { LanguageProvider, useTranslation } from '@/contexts/LanguageContext';
 
 jest.mock('@/hooks/useAuth', () => ({
   useAuth: jest.fn(() => ({ user: null, isLoading: false, isAuthenticated: false })),

--- a/jestSetup.ts
+++ b/jestSetup.ts
@@ -41,6 +41,24 @@ jest.mock('@better-auth/expo/client', () => ({
   expoClient: jest.fn(),
 }));
 
+// Provide a default LanguageProvider/useTranslation so components that consume
+// the i18n context can render under test without each test having to wrap in
+// the real provider. Defaults to the Norwegian translations so existing tests
+// that match Norwegian copy keep working. Individual tests can override with
+// jest.spyOn / jest.doMock if they need a different locale.
+jest.mock('@/contexts/LanguageContext', () => {
+  const { no } = require('@/lib/i18n/translations/no');
+  return {
+    LanguageProvider: ({ children }: { children: React.ReactNode }) => children,
+    useTranslation: () => ({
+      locale: 'no',
+      t: no,
+      setLanguage: jest.fn().mockResolvedValue(undefined),
+      isLoaded: true,
+    }),
+  };
+});
+
 // Mock expo-router
 jest.mock('expo-router', () => ({
   ...jest.requireActual('expo-router'),

--- a/lib/i18n/translations/en.ts
+++ b/lib/i18n/translations/en.ts
@@ -7,4 +7,49 @@ export const en: TranslationKeys = {
   'language.english': 'English',
   'language.current': 'Current',
   'language.switchTo': 'Switch to',
+
+  'intro.tagline': 'Training tracker for archers',
+  'intro.titleLine1': 'Every shot',
+  'intro.titleLine2': 'counts.',
+  'intro.body':
+    'Log practices and competitions, track your sight marks and follow your progress over time. Everything you need to become a better archer.',
+  'intro.getStarted': 'Get started',
+
+  'auth.emailLabel': 'Email',
+  'auth.passwordLabel': 'Password',
+  'auth.loginButton': 'Log in',
+  'auth.registerButton': 'Create account',
+  'auth.loginWithGoogle': 'Continue with Google',
+  'auth.errorTitle': 'Error',
+  'auth.toggleToRegister': 'Sign up',
+  'auth.toggleToLogin': 'Log in',
+  'auth.divider': 'or',
+
+  'validation.emailPasswordRequired': 'Email and password are required',
+  'validation.passwordMinLength': 'Password must be at least 8 characters',
+  'validation.genericError': 'An error occurred',
+
+  'common.loading': 'Loading...',
+  'common.success': 'Success',
+  'common.error': 'Error',
+
+  'emailVerification.title': 'Verify your email',
+  'emailVerification.sentTo': "We've sent a verification link to",
+  'emailVerification.instructions':
+    'Click the link in the email to verify your account. Once verified, come back here and tap "I have verified".',
+  'emailVerification.checkButton': 'I have verified',
+  'emailVerification.resendButton': 'Resend email',
+  'emailVerification.resendCooldown': 'Resend',
+  'emailVerification.sendingEmail': 'Sending email...',
+  'emailVerification.checkingStatus': 'Checking status...',
+  'emailVerification.notVerifiedYet': 'Email not verified yet. Please check your inbox.',
+  'emailVerification.checkFailed': 'Failed to check verification status',
+  'emailVerification.sentSuccess': 'Verification email sent! Check your inbox.',
+  'emailVerification.sendFailed': 'Failed to resend email',
+  'emailVerification.helpText': 'Didn\'t receive the email? Check your spam folder or tap "Resend email".',
+
+  'emailBanner.notVerified': 'Your email is not verified.',
+  'emailBanner.resend': 'Resend verification',
+  'emailBanner.sending': 'Sending...',
+  'emailBanner.sendError': 'Failed to send verification email. Please try again.',
 };

--- a/lib/i18n/translations/no.ts
+++ b/lib/i18n/translations/no.ts
@@ -7,4 +7,49 @@ export const no: TranslationKeys = {
   'language.english': 'Engelsk',
   'language.current': 'Nåværende',
   'language.switchTo': 'Bytt til',
+
+  'intro.tagline': 'Treningsporing for bueskyttere',
+  'intro.titleLine1': 'Hvert skudd',
+  'intro.titleLine2': 'teller.',
+  'intro.body':
+    'Logg treninger og konkurranser, spor siktmerkene dine og følg fremgangen over tid. Alt du trenger for å bli en bedre bueskytter.',
+  'intro.getStarted': 'Kom i gang',
+
+  'auth.emailLabel': 'E-post',
+  'auth.passwordLabel': 'Passord',
+  'auth.loginButton': 'Logg inn',
+  'auth.registerButton': 'Opprett konto',
+  'auth.loginWithGoogle': 'Fortsett med Google',
+  'auth.errorTitle': 'Feil',
+  'auth.toggleToRegister': 'Registrer deg',
+  'auth.toggleToLogin': 'Logg inn',
+  'auth.divider': 'eller',
+
+  'validation.emailPasswordRequired': 'E-post og passord er påkrevd',
+  'validation.passwordMinLength': 'Passordet må være minst 8 tegn',
+  'validation.genericError': 'Det oppstod en feil',
+
+  'common.loading': 'Venter...',
+  'common.success': 'Suksess',
+  'common.error': 'Feil',
+
+  'emailVerification.title': 'Bekreft e-postadressen din',
+  'emailVerification.sentTo': 'Vi har sendt en bekreftelseslenke til',
+  'emailVerification.instructions':
+    'Klikk på lenken i e-posten for å bekrefte kontoen din. Når du har bekreftet, kan du komme tilbake hit og trykke på "Jeg har bekreftet".',
+  'emailVerification.checkButton': 'Jeg har bekreftet',
+  'emailVerification.resendButton': 'Send e-post på nytt',
+  'emailVerification.resendCooldown': 'Send på nytt',
+  'emailVerification.sendingEmail': 'Sender e-post...',
+  'emailVerification.checkingStatus': 'Sjekker status...',
+  'emailVerification.notVerifiedYet': 'E-posten er ikke bekreftet ennå. Sjekk innboksen din.',
+  'emailVerification.checkFailed': 'Kunne ikke sjekke bekreftelsesstatus',
+  'emailVerification.sentSuccess': 'Bekreftelses-e-post sendt! Sjekk innboksen din.',
+  'emailVerification.sendFailed': 'Kunne ikke sende e-posten på nytt',
+  'emailVerification.helpText': 'Fikk du ikke e-posten? Sjekk søppelpostmappen din eller klikk "Send e-post på nytt".',
+
+  'emailBanner.notVerified': 'E-posten din er ikke bekreftet.',
+  'emailBanner.resend': 'Send bekreftelse på nytt',
+  'emailBanner.sending': 'Sender...',
+  'emailBanner.sendError': 'Kunne ikke sende bekreftelses-e-post. Prøv igjen.',
 };

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -1,10 +1,8 @@
 export type Locale = 'no' | 'en';
 
-// Phase 1 seeds the type with the keys actually consumed by the
-// LanguageProvider's UI (the settings language section). Subsequent phases
-// will mirror the web app's TranslationKeys interface as each screen is
-// migrated. Keep key names aligned with the web app so the translations can
-// eventually be shared.
+// Translation keys are added in batches as each screen is migrated. Names
+// mirror the web app's TranslationKeys where possible so the two locale
+// sets can eventually be shared.
 export interface TranslationKeys {
   // Language switcher (in Settings)
   'language.sectionTitle': string;
@@ -13,4 +11,53 @@ export interface TranslationKeys {
   'language.english': string;
   'language.current': string;
   'language.switchTo': string;
+
+  // Intro screen
+  'intro.tagline': string;
+  'intro.titleLine1': string;
+  'intro.titleLine2': string;
+  'intro.body': string;
+  'intro.getStarted': string;
+
+  // Auth screen
+  'auth.emailLabel': string;
+  'auth.passwordLabel': string;
+  'auth.loginButton': string;
+  'auth.registerButton': string;
+  'auth.loginWithGoogle': string;
+  'auth.errorTitle': string;
+  'auth.toggleToRegister': string;
+  'auth.toggleToLogin': string;
+  'auth.divider': string;
+
+  // Validation
+  'validation.emailPasswordRequired': string;
+  'validation.passwordMinLength': string;
+  'validation.genericError': string;
+
+  // Common
+  'common.loading': string;
+  'common.success': string;
+  'common.error': string;
+
+  // Email verification screen
+  'emailVerification.title': string;
+  'emailVerification.sentTo': string;
+  'emailVerification.instructions': string;
+  'emailVerification.checkButton': string;
+  'emailVerification.resendButton': string;
+  'emailVerification.resendCooldown': string;
+  'emailVerification.sendingEmail': string;
+  'emailVerification.checkingStatus': string;
+  'emailVerification.notVerifiedYet': string;
+  'emailVerification.checkFailed': string;
+  'emailVerification.sentSuccess': string;
+  'emailVerification.sendFailed': string;
+  'emailVerification.helpText': string;
+
+  // Email verification banner
+  'emailBanner.notVerified': string;
+  'emailBanner.resend': string;
+  'emailBanner.sending': string;
+  'emailBanner.sendError': string;
 }


### PR DESCRIPTION
First Phase 2 slice — wires translations through the smallest user-visible surface (intro + auth).

## Summary
- `app/intro.tsx`, `app/auth.tsx`, and every component under `components/auth/*` (AuthForm, AuthToggle, SocialLogin, EmailVerification, EmailVerificationBanner) now read all user-facing strings via `useTranslation()` from the LanguageProvider added in #173.
- Adds ~35 keys to `TranslationKeys` covering intro hero copy, auth labels/buttons, validation errors, common loading/success/error, and the full email-verification flow.
- Both `no` and `en` translation files are filled in; key names mirror the web app where possible so the locale sets can eventually be shared.

## Why
- Phase 2 from the original i18n plan — migrate screens to the i18n infrastructure one slice at a time.
- Intro + auth is the smallest end-to-end-visible slice to ship first.

## Test plan
- [x] `npm test` — 402 tests, all green
- [x] `npm run lint` — back to the 2 pre-existing warnings; no new ones
- [ ] Launch the app on iOS / Android, switch locale in Settings, verify the intro hero copy, the email/password labels, the "or" divider, the Google button, the toggle link, and the error toast all flip language
- [ ] Trigger the email-verification screen (register a new user) and confirm the title, instructions, button labels, cooldown text, and help text all translate

## Notes for reviewer
- `jestSetup.ts` ships a new default mock for `@/contexts/LanguageContext` so existing component tests render without having to wrap in a real provider. The provider's own test opts back out via `jest.unmock()` so it exercises the real implementation.
- `EmailVerification.tsx` was already using English copy for some alerts even though the rest of the screen was Norwegian — those have been moved into keys too so Norwegian users now see consistent Norwegian text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)