### PR TITLE
feat(i18n): translate settings, equipment forms, and common components

### DIFF
--- a/app/(tabs)/settings/index.tsx
+++ b/app/(tabs)/settings/index.tsx
@@ -13,9 +13,11 @@ import { userRepository } from '@/services/repositories';
 import { AppError } from '@/services';
 import { AccountSection, PublicProfileSection, PrivacySection, SponsorCard, LanguageSection } from '@/components/settings';
 import { EmailVerificationBanner } from '@/components/auth';
+import { useTranslation } from '@/contexts';
 
 export default function Settings() {
   const { logout, deleteAccount, user, refreshUser } = useAuth();
+  const { t } = useTranslation();
   const insets = useSafeAreaInsets();
 
   const [isLoggingOut, setIsLoggingOut] = useState(false);
@@ -52,7 +54,7 @@ export default function Settings() {
       await deleteAccount();
     } catch (error: any) {
       console.error('Error deleting account:', error);
-      Alert.alert('Feil', error?.message || 'Kunne ikke slette konto. Prøv igjen.');
+      Alert.alert(t['common.error'], error?.message || t['settings.deleteError']);
     } finally {
       setIsDeleting(false);
       setShowDeleteConfirm(false);
@@ -68,7 +70,7 @@ export default function Settings() {
         <ScrollView
           contentContainerStyle={[styles.contentContainer, { paddingBottom: insets.bottom + 92 }]}
           showsVerticalScrollIndicator={false}>
-          <Text style={styles.title}>Innstillinger</Text>
+          <Text style={styles.title}>{t['settings.title']}</Text>
           {user && <AccountSection user={user} onProfileUpdate={handleProfileUpdate} />}
           <PublicProfileSection user={user} />
           <LanguageSection />
@@ -78,7 +80,7 @@ export default function Settings() {
             <View style={styles.cardDivider} />
             <Button
               variant="tertiary"
-              label={isLoggingOut ? 'Logger ut...' : 'Logg ut'}
+              label={isLoggingOut ? t['settings.loggingOut'] : t['settings.logout']}
               disabled={isLoggingOut}
               loading={isLoggingOut}
               buttonStyle={styles.logoutButton}
@@ -89,14 +91,11 @@ export default function Settings() {
             />
             <View style={styles.cardDivider} />
             <View style={styles.dangerSection}>
-              <Text style={styles.dangerHeading}>Slett konto</Text>
-              <Text style={styles.dangerDescription}>
-                Når du sletter kontoen din, vil alle dine data bli permanent fjernet. Dette inkluderer treningsøkter, utstyr og
-                profilinformasjon. Denne handlingen kan ikke angres.
-              </Text>
+              <Text style={styles.dangerHeading}>{t['settings.deleteAccount']}</Text>
+              <Text style={styles.dangerDescription}>{t['settings.deleteDescription']}</Text>
               <Button
                 variant="warning"
-                label={isDeleting ? 'Sletter konto...' : 'Slett konto'}
+                label={isDeleting ? t['settings.deletingAccount'] : t['settings.deleteAccount']}
                 disabled={isDeleting || isLoggingOut}
                 loading={isDeleting}
                 onPress={() => setShowDeleteConfirm(true)}
@@ -108,10 +107,10 @@ export default function Settings() {
 
       <ConfirmModal
         visible={showDeleteConfirm}
-        title="Bekreft sletting av konto"
-        message="Er du sikker på at du vil slette kontoen din? Alle dine data vil bli permanent fjernet, inkludert treningsøkter, utstyr og profilinformasjon. Denne handlingen kan ikke angres."
-        confirmLabel="Ja, slett konto"
-        cancelLabel="Avbryt"
+        title={t['settings.confirmDeleteTitle']}
+        message={t['settings.confirmDeleteMessage']}
+        confirmLabel={t['settings.confirmDeleteYes']}
+        cancelLabel={t['common.cancel']}
         onCancel={() => setShowDeleteConfirm(false)}
         onConfirm={handleConfirmDelete}
       />

--- a/components/common/Input/Input.tsx
+++ b/components/common/Input/Input.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { StyleProp, Text, TextInput, TextInputProps, TextStyle, View, ViewStyle } from 'react-native';
 import { defaultStyles } from './InputStyles';
 import { colors } from '@/styles/colors';
+import { useTranslation } from '@/contexts';
 
 interface InputProps extends TextInputProps {
   label: string;
@@ -45,6 +46,7 @@ const Input = React.forwardRef<TextInput, InputProps>(
     },
     ref,
   ) => {
+    const { t } = useTranslation();
     const [isFocused, setIsFocused] = useState(false);
     const showError = Boolean(error);
 
@@ -63,7 +65,7 @@ const Input = React.forwardRef<TextInput, InputProps>(
         <View style={defaultStyles.labelContainer}>
           <Text style={[defaultStyles.label, labelStyle]}>
             {label}
-            {optional && <Text style={defaultStyles.optional}> (valgfritt)</Text>}
+            {optional && <Text style={defaultStyles.optional}> {t['form.optional']}</Text>}
           </Text>
           {info ? <Text style={defaultStyles.infoText}>{info}</Text> : null}
         </View>

--- a/components/common/OfflineBanner/OfflineBanner.tsx
+++ b/components/common/OfflineBanner/OfflineBanner.tsx
@@ -3,10 +3,12 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useNetworkState } from '@/hooks/useNetworkState';
 import { useOfflineQueue } from '@/hooks/useOfflineQueue';
 import { colors } from '@/styles/colors';
+import { useTranslation } from '@/contexts';
 
 export function OfflineBanner() {
   const { isConnected } = useNetworkState();
   const { queueLength, isSyncing, syncNow } = useOfflineQueue();
+  const { t } = useTranslation();
 
   if (isConnected && queueLength === 0) {
     return null;
@@ -15,7 +17,7 @@ export function OfflineBanner() {
   if (!isConnected) {
     return (
       <View style={styles.banner}>
-        <Text style={styles.text}>📴 Frakoblet — endringer synkroniseres når du er tilkoblet</Text>
+        <Text style={styles.text}>📴 {t['offline.disconnected']}</Text>
       </View>
     );
   }
@@ -23,7 +25,9 @@ export function OfflineBanner() {
   if (queueLength > 0) {
     return (
       <Pressable style={styles.banner} onPress={syncNow} disabled={isSyncing}>
-        <Text style={styles.text}>{isSyncing ? '🔄 Jobber...' : `⏳ ${queueLength} i kø - klikk for å synkronisere`}</Text>
+        <Text style={styles.text}>
+          {isSyncing ? `🔄 ${t['offline.syncing']}` : `⏳ ${t['offline.queued'].replace('{count}', String(queueLength))}`}
+        </Text>
       </Pressable>
     );
   }

--- a/components/common/Select/Select.tsx
+++ b/components/common/Select/Select.tsx
@@ -18,6 +18,7 @@ import { colors } from '@/styles/colors';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons/faChevronDown';
 import { faCheck } from '@fortawesome/free-solid-svg-icons/faCheck';
+import { useTranslation } from '@/contexts';
 
 type Option = {
   label: string;
@@ -49,8 +50,10 @@ export const Select: React.FC<Props> = ({
   containerStyle,
   zIndex = 1000,
   searchable = false,
-  placeholder = 'Velg et alternativ',
+  placeholder,
 }) => {
+  const { t } = useTranslation();
+  const resolvedPlaceholder = placeholder ?? t['common.chooseOption'];
   const [open, setOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectBoxPosition, setSelectBoxPosition] = useState({ x: 0, y: 0, width: 0, height: 0 });
@@ -105,7 +108,7 @@ export const Select: React.FC<Props> = ({
     outputRange: ['0deg', '180deg'],
   });
 
-  const selectedLabel = options.find((opt) => opt.value === selectedValue)?.label || placeholder;
+  const selectedLabel = options.find((opt) => opt.value === selectedValue)?.label || resolvedPlaceholder;
 
   const renderOption = (item: Option, index: number) => (
     <Pressable
@@ -131,7 +134,7 @@ export const Select: React.FC<Props> = ({
         filteredOptions.map(renderOption)
       ) : (
         <View style={styles.option}>
-          <Text style={[styles.optionText, { color: colors.dimmed }]}>Ingen treff</Text>
+          <Text style={[styles.optionText, { color: colors.dimmed }]}>{t['common.noResults']}</Text>
         </View>
       )}
     </ScrollView>
@@ -144,7 +147,7 @@ export const Select: React.FC<Props> = ({
       <View style={styles.labelContainer}>
         <Text style={styles.label}>
           {label}
-          {optional && <Text style={styles.optional}> (valgfritt)</Text>}
+          {optional && <Text style={styles.optional}> {t['form.optional']}</Text>}
         </Text>
         {info ? <Text style={styles.infoText}>{info}</Text> : null}
       </View>

--- a/components/common/Textarea/Textarea.tsx
+++ b/components/common/Textarea/Textarea.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Platform, StyleProp, Text, TextInput, TextInputProps, TextStyle, View, ViewStyle } from 'react-native';
 import { defaultStyles } from './TextareaStyles';
 import { colors } from '@/styles/colors';
+import { useTranslation } from '@/contexts';
 
 interface TextareaProps extends TextInputProps {
   label: string;
@@ -39,6 +40,7 @@ const Textarea = React.forwardRef<TextInput, TextareaProps>(
     },
     ref,
   ) => {
+    const { t } = useTranslation();
     const [isFocused, setIsFocused] = useState(false);
 
     const handleFocus = (e: any) => {
@@ -62,7 +64,7 @@ const Textarea = React.forwardRef<TextInput, TextareaProps>(
           {icon && <View style={defaultStyles.icon}>{icon}</View>}
           <Text style={[defaultStyles.label, labelStyle]}>
             {label}
-            {optional && <Text style={defaultStyles.optional}> (valgfritt)</Text>}
+            {optional && <Text style={defaultStyles.optional}> {t['form.optional']}</Text>}
           </Text>
           {info ? <Text style={defaultStyles.infoText}>{info}</Text> : null}
         </View>

--- a/components/common/UpdateRequired/UpdateRequired.tsx
+++ b/components/common/UpdateRequired/UpdateRequired.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, Image } from 'react-native';
 import Button from '@/components/common/Button/Button';
 import { colors } from '@/styles/colors';
 import { VersionService } from '@/services/versionService';
+import { useTranslation } from '@/contexts';
 
 interface UpdateRequiredProps {
   message: string;
@@ -10,6 +11,8 @@ interface UpdateRequiredProps {
 }
 
 export default function UpdateRequired({ message, storeUrl }: UpdateRequiredProps) {
+  const { t } = useTranslation();
+
   const handleUpdate = () => {
     VersionService.openStore(storeUrl);
   };
@@ -18,10 +21,10 @@ export default function UpdateRequired({ message, storeUrl }: UpdateRequiredProp
     <View style={styles.container}>
       <View style={styles.content}>
         <Image source={require('@/assets/images/icon.png')} style={styles.icon} />
-        <Text style={styles.title}>Oppdatering påkrevd</Text>
+        <Text style={styles.title}>{t['update.title']}</Text>
         <Text style={styles.message}>{message}</Text>
-        <Button label="Oppdater nå" onPress={handleUpdate} variant="tertiary" buttonStyle={styles.button} />
-        <Text style={styles.subtext}>Du må oppdatere appen for å fortsette å bruke Bueboka</Text>
+        <Button label={t['update.button']} onPress={handleUpdate} variant="tertiary" buttonStyle={styles.button} />
+        <Text style={styles.subtext}>{t['update.subtext']}</Text>
       </View>
     </View>
   );

--- a/components/home/arrowForm/ArrowForm.tsx
+++ b/components/home/arrowForm/ArrowForm.tsx
@@ -12,6 +12,7 @@ import { colors } from '@/styles/colors';
 import ConfirmModal from '@/components/home/DeleteArrowSetModal/ConfirmModal';
 import { arrowsRepository } from '@/services/repositories';
 import { AppError } from '@/services';
+import { useTranslation } from '@/contexts';
 
 interface Props {
   modalVisible: boolean;
@@ -21,6 +22,7 @@ interface Props {
 }
 
 export default function ArrowForm({ modalVisible, setArrowModalVisible, arrowSet, existingArrowSets }: Props) {
+  const { t } = useTranslation();
   const [confirmVisible, setConfirmVisible] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
@@ -81,11 +83,7 @@ export default function ArrowForm({ modalVisible, setArrowModalVisible, arrowSet
       setArrowModalVisible(false);
     } catch (error) {
       console.error('Error deleting arrows:', error);
-      if (error instanceof AppError) {
-        alert(error.message);
-      } else {
-        alert('Kunne ikke slette pilsett');
-      }
+      alert(error instanceof AppError ? error.message : t['arrowForm.deleteError']);
     } finally {
       setSubmitting(false);
     }
@@ -98,7 +96,7 @@ export default function ArrowForm({ modalVisible, setArrowModalVisible, arrowSet
 
   async function handleSubmit() {
     if (!name) {
-      alert('Navn er påkrevd');
+      alert(t['arrowForm.nameRequired']);
       return;
     }
 
@@ -121,10 +119,8 @@ export default function ArrowForm({ modalVisible, setArrowModalVisible, arrowSet
       };
 
       if (arrowSet) {
-        // Edit mode
         await arrowsRepository.update(arrowSet.id, arrowsData);
       } else {
-        // Create mode
         await arrowsRepository.create(arrowsData);
       }
 
@@ -140,11 +136,7 @@ export default function ArrowForm({ modalVisible, setArrowModalVisible, arrowSet
       setArrowModalVisible(false);
     } catch (error) {
       console.error('Error saving arrows:', error);
-      if (error instanceof AppError) {
-        alert(error.message);
-      } else {
-        alert('Kunne ikke lagre pilsett');
-      }
+      alert(error instanceof AppError ? error.message : t['arrowForm.saveError']);
     } finally {
       setSubmitting(false);
     }
@@ -174,34 +166,34 @@ export default function ArrowForm({ modalVisible, setArrowModalVisible, arrowSet
         setArrowModalVisible(false);
       }}>
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.modal}>
-        <ModalHeader onPress={handleCloseModal} title={arrowSet ? 'Rediger pilsett' : 'Nytt pilsett'} />
+        <ModalHeader onPress={handleCloseModal} title={arrowSet ? t['arrowForm.editTitle'] : t['arrowForm.newTitle']} />
         <ScrollView keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
           <Pressable onPress={() => Keyboard.dismiss()}>
             <View style={styles.inputs}>
               <Input
                 value={name}
                 onChangeText={(value) => dispatch({ type: 'SET_NAME', payload: value })}
-                helpText="F.eks. Carbon X23"
-                label="Navn på pilsett"
-                info="(obligatorisk)"
+                helpText={t['arrowForm.nameHelpText']}
+                label={t['arrowForm.nameLabel']}
+                info={t['arrowForm.nameInfo']}
               />
               <View style={styles.row}>
                 <Select
                   containerStyle={{ flex: 1 }}
-                  label="Materiale"
+                  label={t['arrowDetails.material']}
                   selectedValue={material}
                   options={[
-                    { label: 'Karbon', value: Material.KARBON },
-                    { label: 'Aluminium', value: Material.ALUMINIUM },
-                    { label: 'Treverk', value: Material.TREVERK },
+                    { label: t['arrowMaterial.karbon'], value: Material.KARBON },
+                    { label: t['arrowMaterial.aluminium'], value: Material.ALUMINIUM },
+                    { label: t['arrowMaterial.treverk'], value: Material.TREVERK },
                   ]}
                   onValueChange={(value) => dispatch({ type: 'SET_MATERIAL', payload: value })}
                 />
                 <Input
                   containerStyle={{ flex: 1 }}
-                  label="Antall piler"
+                  label={t['arrowDetails.arrowCount']}
                   keyboardType="numeric"
-                  helpText="F.eks. 12"
+                  helpText={t['arrowForm.arrowCountHelpText']}
                   value={arrowsCount}
                   onChangeText={(value) => handleNumberChange(value, 'SET_ARROWS_COUNT', dispatch)}
                 />
@@ -209,15 +201,14 @@ export default function ArrowForm({ modalVisible, setArrowModalVisible, arrowSet
 
               <Checkbox
                 value={isFavorite}
-                label="Favoritt"
+                label={t['common.favourite']}
                 onChange={(newValue) => dispatch({ type: 'SET_FAVORITE', payload: newValue })}
               />
 
-              {/* ── Avansert ──────────────────────────────────────────────── */}
               <TouchableOpacity activeOpacity={0.7} style={styles.advancedToggle} onPress={() => setAdvancedOpen((prev) => !prev)}>
                 <View style={styles.advancedLine} />
                 <View style={styles.advancedLabelWrap}>
-                  <Text style={styles.advancedLabel}>Avansert</Text>
+                  <Text style={styles.advancedLabel}>{t['common.advanced']}</Text>
                   <FontAwesomeIcon
                     icon={faChevronDown}
                     size={11}
@@ -233,19 +224,19 @@ export default function ArrowForm({ modalVisible, setArrowModalVisible, arrowSet
                   <View style={styles.row}>
                     <Input
                       containerStyle={{ flex: 1 }}
-                      label="Lengde"
-                      info="(tommer)"
+                      label={t['arrowDetails.length']}
+                      info={t['arrowDetails.lengthSuffix']}
                       keyboardType="numeric"
-                      helpText="F.eks. 31"
+                      helpText={t['arrowForm.lengthHelpText']}
                       value={length}
                       onChangeText={(value) => dispatch({ type: 'SET_LENGTH', payload: value })}
                     />
                     <Input
                       containerStyle={{ flex: 1 }}
-                      label="Vekt"
-                      info="(grain)"
+                      label={t['arrowDetails.weight']}
+                      info={t['arrowForm.grainSuffix']}
                       keyboardType="numeric"
-                      helpText="F.eks. 400"
+                      helpText={t['arrowForm.weightHelpText']}
                       value={weight}
                       onChangeText={(value) => handleNumberChange(value, 'SET_WEIGHT', dispatch)}
                     />
@@ -253,17 +244,17 @@ export default function ArrowForm({ modalVisible, setArrowModalVisible, arrowSet
                   <View style={styles.row}>
                     <Input
                       containerStyle={{ flex: 1 }}
-                      label="Spine"
-                      helpText="F.eks. 500"
+                      label={t['arrowDetails.spine']}
+                      helpText={t['arrowForm.spineHelpText']}
                       value={spine}
                       onChangeText={(value) => dispatch({ type: 'SET_SPINE', payload: value })}
                     />
                     <Input
                       containerStyle={{ flex: 1 }}
-                      label="Diameter"
-                      info="(mm)"
+                      label={t['arrowDetails.diameter']}
+                      info={t['arrowForm.mmSuffix']}
                       keyboardType="numeric"
-                      helpText="F.eks. 5.2"
+                      helpText={t['arrowForm.diameterHelpText']}
                       value={diameter}
                       onChangeText={(value) => handleNumberChange(value, 'SET_DIAMETER', dispatch)}
                     />
@@ -271,30 +262,30 @@ export default function ArrowForm({ modalVisible, setArrowModalVisible, arrowSet
                   <View style={styles.row}>
                     <Input
                       containerStyle={{ flex: 1 }}
-                      label="Pilspisstype"
-                      helpText="F.eks. Bullet"
+                      label={t['arrowDetails.pointType']}
+                      helpText={t['arrowForm.pointTypeHelpText']}
                       value={pointType}
                       onChangeText={(value) => dispatch({ type: 'SET_POINT_TYPE', payload: value })}
                     />
                     <Input
                       containerStyle={{ flex: 1 }}
-                      label="Spissvekt"
-                      info="(grain)"
+                      label={t['arrowDetails.pointWeight']}
+                      info={t['arrowForm.grainSuffix']}
                       keyboardType="numeric"
-                      helpText="F.eks. 100"
+                      helpText={t['arrowForm.pointWeightHelpText']}
                       value={pointWeight}
                       onChangeText={(value) => handleNumberChange(value, 'SET_POINT_WEIGHT', dispatch)}
                     />
                   </View>
                   <Input
-                    label="Vanes"
-                    helpText="F.eks. Bohning X Vanes"
+                    label={t['arrowDetails.vanes']}
+                    helpText={t['arrowForm.vanesHelpText']}
                     value={vanes}
                     onChangeText={(value) => dispatch({ type: 'SET_VANES', payload: value })}
                   />
                   <Input
-                    label="Nock"
-                    helpText="F.eks. Easton G Nock"
+                    label={t['arrowDetails.nock']}
+                    helpText={t['arrowForm.nockHelpText']}
                     value={nock}
                     onChangeText={(value) => dispatch({ type: 'SET_NOCK', payload: value })}
                   />
@@ -302,19 +293,24 @@ export default function ArrowForm({ modalVisible, setArrowModalVisible, arrowSet
               )}
 
               <Textarea
-                label="Notater"
+                label={t['arrowDetails.notes']}
                 optional
                 value={notes}
                 onChangeText={(value) => dispatch({ type: 'SET_NOTES', payload: value })}
-                placeholder="Ekstra informasjon om pilsettet"
+                placeholder={t['arrowForm.notesPlaceholder']}
               />
             </View>
           </Pressable>
         </ScrollView>
         <View style={styles.footer}>
-          <Button disabled={!name || submitting} onPress={handleSubmit} label={submitting ? 'Lagrer...' : 'Lagre'} />
+          <Button disabled={!name || submitting} onPress={handleSubmit} label={submitting ? t['form.saving'] : t['form.save']} />
           {arrowSet && (
-            <Button variant="warning" label="Slett" onPress={() => setConfirmVisible(true)} type="outline" disabled={submitting}>
+            <Button
+              variant="warning"
+              label={t['common.delete']}
+              onPress={() => setConfirmVisible(true)}
+              type="outline"
+              disabled={submitting}>
               <FontAwesomeIcon icon={faTrash} size={16} color={colors.warning} />
             </Button>
           )}
@@ -325,13 +321,13 @@ export default function ArrowForm({ modalVisible, setArrowModalVisible, arrowSet
               clearForm();
               setArrowModalVisible(false);
             }}
-            label="Avbryt"
+            label={t['common.cancel']}
           />
         </View>
       </KeyboardAvoidingView>
       <ConfirmModal
-        title={'Slett pilsett'}
-        message={'Vil du slette pilsettet "' + arrowSet?.name + '"?'}
+        title={t['arrowForm.deleteTitle']}
+        message={t['arrowForm.deleteMessage'].replace('{name}', arrowSet?.name ?? '')}
         visible={confirmVisible}
         onCancel={() => setConfirmVisible(false)}
         onConfirm={() => {

--- a/components/home/bowForm/BowForm.tsx
+++ b/components/home/bowForm/BowForm.tsx
@@ -12,6 +12,7 @@ import { colors } from '@/styles/colors';
 import ConfirmModal from '@/components/home/DeleteArrowSetModal/ConfirmModal';
 import { bowRepository } from '@/services/repositories';
 import { AppError } from '@/services';
+import { useTranslation } from '@/contexts';
 
 interface BowFormProps {
   modalVisible: boolean;
@@ -23,6 +24,7 @@ interface BowFormProps {
 }
 
 const BowForm = ({ modalVisible, setModalVisible, bow, existingBows = [], onSuccess, onDeleteSuccess }: BowFormProps) => {
+  const { t } = useTranslation();
   const [confirmVisible, setConfirmVisible] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
@@ -87,12 +89,10 @@ const BowForm = ({ modalVisible, setModalVisible, bow, existingBows = [], onSucc
       };
 
       if (bow) {
-        // Edit mode
         await bowRepository.update(bow.id, bowData);
       } else {
-        // Create mode
         if (bows.length >= 5) {
-          alert('Du kan ikke ha mer enn 5 buer');
+          alert(t['bowForm.maxBowsError']);
           return;
         }
         await bowRepository.create(bowData);
@@ -103,11 +103,7 @@ const BowForm = ({ modalVisible, setModalVisible, bow, existingBows = [], onSucc
       onSuccess?.();
     } catch (error) {
       console.error('Error saving bow:', error);
-      if (error instanceof AppError) {
-        alert(error.message);
-      } else {
-        alert('Kunne ikke lagre bue');
-      }
+      alert(error instanceof AppError ? error.message : t['bowForm.saveError']);
     } finally {
       setSubmitting(false);
     }
@@ -125,11 +121,7 @@ const BowForm = ({ modalVisible, setModalVisible, bow, existingBows = [], onSucc
       onSuccess?.();
     } catch (error) {
       console.error('Error deleting bow:', error);
-      if (error instanceof AppError) {
-        alert(error.message);
-      } else {
-        alert('Kunne ikke slette bue');
-      }
+      alert(error instanceof AppError ? error.message : t['bowForm.deleteError']);
     } finally {
       setSubmitting(false);
     }
@@ -164,41 +156,41 @@ const BowForm = ({ modalVisible, setModalVisible, bow, existingBows = [], onSucc
         setModalVisible(false);
       }}>
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.modal}>
-        <ModalHeader onPress={handleCloseModal} title={bow ? 'Rediger bue' : 'Ny bue'} />
+        <ModalHeader onPress={handleCloseModal} title={bow ? t['bowForm.editTitle'] : t['bowForm.newTitle']} />
         <ScrollView keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
           <Pressable onPress={() => Keyboard.dismiss()}>
             <View style={styles.inputs}>
               <Input
                 value={name}
                 onChangeText={(value) => dispatch({ type: 'SET_NAME', payload: value })}
-                label="Navn på bue"
+                label={t['bowForm.nameLabel']}
                 error={nameError}
-                errorMessage="Du må fylle inn navn på bue"
+                errorMessage={t['bowForm.nameRequired']}
               />
               <Select
                 containerStyle={{ zIndex: 2000 }}
-                label="Buetype"
+                label={t['bowForm.typeLabel']}
                 selectedValue={type}
                 options={[
-                  { label: 'Recurve', value: BowType.RECURVE },
-                  { label: 'Compound', value: BowType.COMPOUND },
-                  { label: 'Langbue', value: BowType.LONGBOW },
-                  { label: 'Barebow', value: BowType.BAREBOW },
-                  { label: 'Rytterbue', value: BowType.HORSEBOW },
-                  { label: 'Tradisjonell', value: BowType.TRADITIONAL },
-                  { label: 'Annet', value: BowType.OTHER },
+                  { label: t['bowType.recurve'], value: BowType.RECURVE },
+                  { label: t['bowType.compound'], value: BowType.COMPOUND },
+                  { label: t['bowType.longbow'], value: BowType.LONGBOW },
+                  { label: t['bowType.barebow'], value: BowType.BAREBOW },
+                  { label: t['bowType.horsebow'], value: BowType.HORSEBOW },
+                  { label: t['bowType.traditional'], value: BowType.TRADITIONAL },
+                  { label: t['bowType.other'], value: BowType.OTHER },
                 ]}
                 onValueChange={(value) => dispatch({ type: 'SET_TYPE', payload: value })}
               />
               <Checkbox
                 value={isFavorite}
-                label="Favoritt"
+                label={t['common.favourite']}
                 onChange={(newValue) => dispatch({ type: 'SET_IS_FAVORITE', payload: newValue })}
               />
               <TouchableOpacity activeOpacity={0.7} style={styles.advancedToggle} onPress={() => setAdvancedOpen((prev) => !prev)}>
                 <View style={styles.advancedLine} />
                 <View style={styles.advancedLabelWrap}>
-                  <Text style={styles.advancedLabel}>Avansert</Text>
+                  <Text style={styles.advancedLabel}>{t['common.advanced']}</Text>
                   <FontAwesomeIcon
                     icon={faChevronDown}
                     size={11}
@@ -212,25 +204,25 @@ const BowForm = ({ modalVisible, setModalVisible, bow, existingBows = [], onSucc
                 <View style={styles.advancedContent}>
                   <Select
                     containerStyle={{ flex: 1, zIndex: 1500 }}
-                    label="Hånd"
+                    label={t['bowDetails.hand']}
                     selectedValue={handOrientation}
                     options={[
-                      { label: 'Velg hånd', value: '' },
-                      { label: 'Høyre (RH)', value: 'RH' },
-                      { label: 'Venstre (LH)', value: 'LH' },
+                      { label: t['bowForm.handPlaceholder'], value: '' },
+                      { label: t['bowDetails.handRH'], value: 'RH' },
+                      { label: t['bowDetails.handLH'], value: 'LH' },
                     ]}
                     onValueChange={(value) => dispatch({ type: 'SET_HAND_ORIENTATION', payload: value as 'RH' | 'LH' | '' })}
                   />
                   <View style={styles.row}>
                     <Input
                       containerStyle={{ flex: 1 }}
-                      label="Lemmer"
+                      label={t['bowDetails.limbs']}
                       value={limbs}
                       onChangeText={(value) => dispatch({ type: 'SET_LIMBS', payload: value })}
                     />
                     <Input
                       containerStyle={{ flex: 1 }}
-                      label="Midtstykke"
+                      label={t['bowDetails.riser']}
                       value={riser}
                       onChangeText={(value) => dispatch({ type: 'SET_RISER', payload: value })}
                     />
@@ -238,14 +230,14 @@ const BowForm = ({ modalVisible, setModalVisible, bow, existingBows = [], onSucc
                   <View style={styles.numberRow}>
                     <Input
                       containerStyle={{ flex: 1 }}
-                      label="Styrke (pund)"
+                      label={t['bowForm.drawWeight']}
                       keyboardType="numeric"
                       value={drawWeight}
                       onChangeText={(value) => handleNumberChange(value, 'SET_DRAW_WEIGHT', dispatch)}
                     />
                     <Input
                       containerStyle={{ flex: 1 }}
-                      label="Lengde (tommer)"
+                      label={t['bowForm.bowLength']}
                       keyboardType="numeric"
                       value={bowLength}
                       onChangeText={(value) => handleNumberChange(value, 'SET_BOW_LENGTH', dispatch)}
@@ -256,7 +248,7 @@ const BowForm = ({ modalVisible, setModalVisible, bow, existingBows = [], onSucc
               <TouchableOpacity activeOpacity={0.7} style={styles.advancedToggle} onPress={() => setSightMarkOpen((prev) => !prev)}>
                 <View style={styles.advancedLine} />
                 <View style={styles.advancedLabelWrap}>
-                  <Text style={styles.advancedLabel}>Siktemerke</Text>
+                  <Text style={styles.advancedLabel}>{t['bowForm.sightMarksSection']}</Text>
                   <FontAwesomeIcon
                     icon={faChevronDown}
                     size={11}
@@ -271,21 +263,21 @@ const BowForm = ({ modalVisible, setModalVisible, bow, existingBows = [], onSucc
                 <View style={styles.numberRow}>
                   <Input
                     containerStyle={{ flex: 1 }}
-                    label="Øye til nock (cm)"
+                    label={t['bowForm.eyeToNock']}
                     keyboardType="numeric"
                     value={eyeToNock}
                     onChangeText={(value) => handleNumberChange(value, 'SET_EYE_TO_NOCK', dispatch)}
                   />
                   <Input
                     containerStyle={{ flex: 1 }}
-                    label="Øye til sikte (cm)"
+                    label={t['bowForm.eyeToSight']}
                     keyboardType="numeric"
                     value={eyeToSight}
                     onChangeText={(value) => handleNumberChange(value, 'SET_EYE_TO_SIGHT', dispatch)}
                   />
                   <Input
                     containerStyle={{ flex: 1 }}
-                    label="Målt sikte"
+                    label={t['bowDetails.aimMeasure']}
                     keyboardType="numeric"
                     value={aimMeasure}
                     onChangeText={(value) => handleNumberChange(value, 'SET_AIM_MEASURE', dispatch)}
@@ -294,11 +286,11 @@ const BowForm = ({ modalVisible, setModalVisible, bow, existingBows = [], onSucc
               )}
 
               <Textarea
-                label="Notater"
+                label={t['bowDetails.notes']}
                 optional
                 value={notes}
                 onChangeText={(value) => dispatch({ type: 'SET_NOTES', payload: value })}
-                placeholderText="F.eks. Spesielle innstillinger eller justeringer"
+                placeholderText={t['bowForm.notesPlaceholder']}
               />
             </View>
           </Pressable>
@@ -309,23 +301,23 @@ const BowForm = ({ modalVisible, setModalVisible, bow, existingBows = [], onSucc
               <FontAwesomeIcon icon={faTrashCan} size={16} color={colors.error} />
             </TouchableOpacity>
           )}
-          <Button disabled={!name || submitting} onPress={handleSubmit} label={submitting ? 'Lagrer...' : 'Lagre'} />
+          <Button disabled={!name || submitting} onPress={handleSubmit} label={submitting ? t['form.saving'] : t['form.save']} />
           <Button
             type="outline"
             onPress={() => {
               clearForm();
               setModalVisible(false);
             }}
-            label="Avbryt"
+            label={t['common.cancel']}
           />
         </View>
       </KeyboardAvoidingView>
       <ConfirmModal
         visible={confirmVisible}
-        title="Slett bue"
-        message={'Vil du slette buen "' + name + '"?'}
-        confirmLabel="Slett"
-        cancelLabel="Avbryt"
+        title={t['bowForm.deleteTitle']}
+        message={t['bowForm.deleteMessage'].replace('{name}', name)}
+        confirmLabel={t['common.delete']}
+        cancelLabel={t['common.cancel']}
         onCancel={() => setConfirmVisible(false)}
         onConfirm={() => {
           handleDelete();

--- a/components/home/profileForm/ProfileForm.tsx
+++ b/components/home/profileForm/ProfileForm.tsx
@@ -4,6 +4,7 @@ import { Button, Input, ModalWrapper, Select } from '@/components/common';
 import { styles } from './ProfileFormStyles';
 import { User } from '@/types';
 import { NORWEGIAN_ARCHERY_CLUBS } from '@/utils/NorwegianClubs';
+import { useTranslation } from '@/contexts';
 
 interface Props {
   modalVisible: boolean;
@@ -12,20 +13,21 @@ interface Props {
   onSave: (data: { name: string; club?: string; skytternr?: string }) => void;
 }
 
-const CLUB_OPTIONS = [{ value: '', label: 'Ingen / ikke tilknyttet' }, ...NORWEGIAN_ARCHERY_CLUBS];
-
 export default function ProfileForm({ modalVisible, setModalVisible, user, onSave }: Props) {
+  const { t } = useTranslation();
   const [name, setName] = useState(user.name || '');
   const [club, setClub] = useState(user.club || '');
   const [skytternr, setSkytternr] = useState(user.skytternr || '');
   const [errors, setErrors] = useState({ name: '' });
+
+  const CLUB_OPTIONS = [{ value: '', label: t['profileForm.noClub'] }, ...NORWEGIAN_ARCHERY_CLUBS];
 
   const validate = () => {
     const newErrors = { name: '' };
     let isValid = true;
 
     if (!name.trim()) {
-      newErrors.name = 'Navn er påkrevd';
+      newErrors.name = t['profileForm.nameRequired'];
       isValid = false;
     }
 
@@ -47,30 +49,36 @@ export default function ProfileForm({ modalVisible, setModalVisible, user, onSav
   return (
     <ModalWrapper visible={modalVisible} onClose={() => setModalVisible(false)}>
       <View style={styles.modalView}>
-        <Text style={styles.title}>Rediger profil</Text>
+        <Text style={styles.title}>{t['profileBox.editProfile']}</Text>
         <View style={styles.form}>
           <Input
-            label="Navn"
+            label={t['profileForm.nameLabel']}
             value={name}
             onChangeText={setName}
             error={!!errors.name}
             errorMessage={errors.name}
             autoCapitalize="words"
-            helpText="Ditt fulle navn"
+            helpText={t['profileForm.nameHelpText']}
           />
           <Select
-            label="Klubb"
+            label={t['profileForm.clubLabel']}
             options={CLUB_OPTIONS}
             selectedValue={club}
             onValueChange={setClub}
             searchable={true}
-            placeholder="Velg en klubb"
+            placeholder={t['profileForm.clubPlaceholder']}
           />
-          <Input label="Skytternr" value={skytternr} onChangeText={setSkytternr} autoCapitalize="none" helpText="Ditt skytternummer" />
+          <Input
+            label={t['profileForm.archerNumberLabel']}
+            value={skytternr}
+            onChangeText={setSkytternr}
+            autoCapitalize="none"
+            helpText={t['profileForm.archerNumberHelpText']}
+          />
         </View>
         <View style={styles.buttons}>
-          <Button label="Avbryt" onPress={() => setModalVisible(false)} type="outline" />
-          <Button label="Lagre" onPress={handleSave} />
+          <Button label={t['common.cancel']} onPress={() => setModalVisible(false)} type="outline" />
+          <Button label={t['form.save']} onPress={handleSave} />
         </View>
       </View>
     </ModalWrapper>

--- a/components/settings/AccountSection.tsx
+++ b/components/settings/AccountSection.tsx
@@ -7,6 +7,7 @@ import { colors } from '@/styles/colors';
 import { styles } from '@/components/settings/SettingsStyles';
 import ProfileForm from '@/components/home/profileForm/ProfileForm';
 import { User } from '@/types';
+import { useTranslation } from '@/contexts';
 
 interface AccountSectionProps {
   user: User;
@@ -14,37 +15,38 @@ interface AccountSectionProps {
 }
 
 export default function AccountSection({ user, onProfileUpdate }: AccountSectionProps) {
+  const { t } = useTranslation();
   const [isProfileModalVisible, setIsProfileModalVisible] = useState(false);
 
   return (
     <>
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Konto</Text>
+        <Text style={styles.sectionTitle}>{t['settings.accountTitle']}</Text>
         <View style={styles.sectionCard}>
           <View style={styles.infoGrid}>
             <View style={styles.infoGridItem}>
-              <Text style={styles.label}>Navn</Text>
+              <Text style={styles.label}>{t['settings.accountNameLabel']}</Text>
               <Text style={styles.value}>{user.name ?? '—'}</Text>
             </View>
             <View style={styles.infoGridItem}>
-              <Text style={styles.label}>E-post</Text>
+              <Text style={styles.label}>{t['settings.accountEmailLabel']}</Text>
               <Text style={styles.value} numberOfLines={1}>
                 {user.email}
               </Text>
             </View>
             <View style={styles.infoGridItem}>
-              <Text style={styles.label}>Klubb</Text>
+              <Text style={styles.label}>{t['settings.accountClubLabel']}</Text>
               <Text style={styles.value}>{user.club ?? '—'}</Text>
             </View>
             <View style={styles.infoGridItem}>
-              <Text style={styles.label}>Skytternummer</Text>
+              <Text style={styles.label}>{t['settings.accountArcherNumberLabel']}</Text>
               <Text style={styles.value}>{user.skytternr ?? '—'}</Text>
             </View>
           </View>
           <View style={styles.editButtonRow}>
             <Button
               type="outline"
-              label="Rediger profil"
+              label={t['profileBox.editProfile']}
               onPress={() => setIsProfileModalVisible(true)}
               icon={<FontAwesomeIcon icon={faPen} size={13} color={colors.primary} />}
               iconPosition="left"

--- a/components/settings/PrivacySection.tsx
+++ b/components/settings/PrivacySection.tsx
@@ -7,47 +7,39 @@ import { faShield } from '@fortawesome/free-solid-svg-icons/faShield';
 import { faChartBar } from '@fortawesome/free-solid-svg-icons/faChartBar';
 import { colors } from '@/styles/colors';
 import { styles } from '@/components/settings/SettingsStyles';
+import { useTranslation } from '@/contexts';
+import type { TranslationKeys } from '@/lib/i18n/types';
 
-const privacyItems = [
-  {
-    icon: faLock,
-    title: 'Aldri delt eller solgt',
-    desc: 'Vi deler eller selger aldri dataene dine til tredjeparter. Din informasjon forblir privat.',
-  },
-  {
-    icon: faBullseye,
-    title: 'Kun til appens drift',
-    desc: 'Vi bruker kun dataene dine til å drive appen og gi deg den beste brukeropplevelsen.',
-  },
-  {
-    icon: faKey,
-    title: 'Din kontroll',
-    desc: 'Du kan når som helst slette kontoen din og all tilhørende data.',
-  },
-  {
-    icon: faShield,
-    title: 'Sikker lagring',
-    desc: 'All data krypteres og lagres sikkert i samsvar med moderne sikkerhetsstandarder.',
-  },
+type PrivacyItem = {
+  icon: any;
+  titleKey: keyof TranslationKeys;
+  descKey: keyof TranslationKeys;
+};
+
+const PRIVACY_ITEMS: PrivacyItem[] = [
+  { icon: faLock, titleKey: 'settings.privacyNeverSharedTitle', descKey: 'settings.privacyNeverSharedDesc' },
+  { icon: faBullseye, titleKey: 'settings.privacyAppOnlyTitle', descKey: 'settings.privacyAppOnlyDesc' },
+  { icon: faKey, titleKey: 'settings.privacyYourControlTitle', descKey: 'settings.privacyYourControlDesc' },
+  { icon: faShield, titleKey: 'settings.privacySecureStorageTitle', descKey: 'settings.privacySecureStorageDesc' },
 ];
 
 export default function PrivacySection() {
+  const { t } = useTranslation();
+
   return (
     <View style={styles.section}>
-      <Text style={styles.sectionTitle}>Personvern og datasikkerhet</Text>
+      <Text style={styles.sectionTitle}>{t['settings.privacyTitle']}</Text>
       <View style={styles.sectionCard}>
-        <Text style={styles.privacyIntro}>
-          Dine data er trygge hos oss. Vi tar personvern på alvor og forplikter oss til å beskytte informasjonen din.
-        </Text>
+        <Text style={styles.privacyIntro}>{t['settings.privacyIntro']}</Text>
         <View style={styles.privacyList}>
-          {privacyItems.map(({ icon, title, desc }) => (
-            <View key={title} style={styles.privacyItem}>
+          {PRIVACY_ITEMS.map(({ icon, titleKey, descKey }) => (
+            <View key={titleKey} style={styles.privacyItem}>
               <View style={styles.privacyIconWrap}>
                 <FontAwesomeIcon icon={icon} size={15} color={colors.primary} />
               </View>
               <View style={styles.privacyItemContent}>
-                <Text style={styles.privacyItemTitle}>{title}</Text>
-                <Text style={styles.privacyItemDesc}>{desc}</Text>
+                <Text style={styles.privacyItemTitle}>{t[titleKey]}</Text>
+                <Text style={styles.privacyItemDesc}>{t[descKey]}</Text>
               </View>
             </View>
           ))}
@@ -56,22 +48,22 @@ export default function PrivacySection() {
               <FontAwesomeIcon icon={faChartBar} size={15} color={colors.primary} />
             </View>
             <View style={styles.privacyItemContent}>
-              <Text style={styles.privacyItemTitle}>Analyse og forbedring</Text>
+              <Text style={styles.privacyItemTitle}>{t['settings.privacyAnalyticsTitle']}</Text>
               <Text style={styles.privacyItemDesc}>
-                Vi bruker{' '}
+                {t['settings.privacyAnalyticsPre']}{' '}
                 <Text style={styles.link} onPress={() => Linking.openURL('https://clarity.microsoft.com/')}>
                   Microsoft Clarity
                 </Text>{' '}
-                for å forstå hvordan appen brukes og forbedre brukeropplevelsen. Les mer i{' '}
+                {t['settings.privacyAnalyticsMid']}{' '}
                 <Text style={styles.link} onPress={() => Linking.openURL('https://privacy.microsoft.com/privacystatement')}>
-                  Microsofts personvernerklæring
+                  {t['settings.privacyMSPrivacy']}
                 </Text>
                 .
               </Text>
             </View>
           </View>
         </View>
-        <Text style={styles.privacyFooter}>Hvis du har spørsmål om hvordan vi håndterer dataene dine, ta gjerne kontakt med oss.</Text>
+        <Text style={styles.privacyFooter}>{t['settings.privacyFooter']}</Text>
       </View>
     </View>
   );

--- a/components/settings/PublicProfileSection.tsx
+++ b/components/settings/PublicProfileSection.tsx
@@ -6,6 +6,7 @@ import { Checkbox } from '@/components/common';
 import { styles } from '@/components/settings/SettingsStyles';
 import { User } from '@/types';
 import { userRepository } from '@/services/repositories';
+import { useTranslation } from '@/contexts';
 
 type FeedbackMsg = { type: 'success' | 'error'; text: string } | null;
 
@@ -14,6 +15,7 @@ interface PublicProfileSectionProps {
 }
 
 export default function PublicProfileSection({ user }: PublicProfileSectionProps) {
+  const { t } = useTranslation();
   const [isPublic, setIsPublic] = useState(false);
   const [publicName, setPublicName] = useState(true);
   const [publicClub, setPublicClub] = useState(true);
@@ -57,10 +59,10 @@ export default function PublicProfileSection({ user }: PublicProfileSectionProps
 
     try {
       await userRepository.updatePublicSettings(updates);
-      setPublicMsg({ type: 'success', text: 'Innstillinger lagret' });
+      setPublicMsg({ type: 'success', text: t['settings.publicSaved'] });
       setTimeout(() => setPublicMsg(null), 3000);
     } catch {
-      setPublicMsg({ type: 'error', text: 'Kunne ikke lagre innstillinger' });
+      setPublicMsg({ type: 'error', text: t['settings.publicSaveError'] });
     } finally {
       setPublicSaving(false);
     }
@@ -70,46 +72,46 @@ export default function PublicProfileSection({ user }: PublicProfileSectionProps
     <View style={styles.section}>
       <View style={styles.sectionTitleRow}>
         <FontAwesomeIcon icon={faGlobe} size={18} color="#fff" />
-        <Text style={styles.sectionTitle}>Offentlig profil</Text>
+        <Text style={styles.sectionTitle}>{t['settings.publicProfileTitle']}</Text>
       </View>
       <View style={styles.sectionCard}>
-        <Text style={styles.privacyIntro}>Gjør profilen din søkbar for andre brukere. Du velger selv hva du ønsker å dele.</Text>
+        <Text style={styles.privacyIntro}>{t['settings.publicProfileIntro']}</Text>
         <Checkbox
           value={isPublic}
-          label="Gjør profilen min offentlig"
+          label={t['settings.makeProfilePublic']}
           onChange={(v) => handlePublicSettingChange({ isPublic: v })}
           disabled={publicSaving}
         />
         {isPublic && (
           <View style={styles.publicSubSettings}>
-            <Text style={styles.publicSubLabel}>Velg hva som vises offentlig:</Text>
+            <Text style={styles.publicSubLabel}>{t['settings.choosePublicFields']}</Text>
             <Checkbox
               value={publicName}
-              label="Navn"
+              label={t['settings.publicName']}
               onChange={(v) => handlePublicSettingChange({ publicName: v })}
               disabled={publicSaving}
             />
             <Checkbox
               value={publicClub}
-              label="Klubb"
+              label={t['settings.publicClub']}
               onChange={(v) => handlePublicSettingChange({ publicClub: v })}
               disabled={publicSaving}
             />
             <Checkbox
               value={publicSkytternr}
-              label="Skytternummer"
+              label={t['settings.publicArcherNumber']}
               onChange={(v) => handlePublicSettingChange({ publicSkytternr: v })}
               disabled={publicSaving}
             />
             <Checkbox
               value={publicStats}
-              label="Statistikk (totalt antall piler og snittpoeng)"
+              label={t['settings.publicStats']}
               onChange={(v) => handlePublicSettingChange({ publicStats: v })}
               disabled={publicSaving}
             />
             <Checkbox
               value={publicAchievements}
-              label="Prestasjoner (antall oppnådde prestasjoner)"
+              label={t['settings.publicAchievements']}
               onChange={(v) => handlePublicSettingChange({ publicAchievements: v })}
               disabled={publicSaving}
             />

--- a/components/settings/SponsorCard.tsx
+++ b/components/settings/SponsorCard.tsx
@@ -4,11 +4,14 @@ import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faExternalLink } from '@fortawesome/free-solid-svg-icons';
 import { colors } from '@/styles/colors';
 import { styles } from '@/components/settings/SettingsStyles';
+import { useTranslation } from '@/contexts';
 
 export default function SponsorCard() {
+  const { t } = useTranslation();
+
   return (
     <View style={styles.sponsorContent}>
-      <Text style={styles.sponsorLabel}>Sponset av</Text>
+      <Text style={styles.sponsorLabel}>{t['settings.sponsorLabel']}</Text>
       <Image
         style={styles.sponsorLogo}
         contentFit="contain"
@@ -21,7 +24,7 @@ export default function SponsorCard() {
         onPress={() => Linking.openURL('https://www.arcticbuesport.no?utm_source=bueboka&utm_medium=bueboka&utm_campaign=bueboka2026')}>
         <View style={styles.sponsorLink}>
           <Text>
-            Besøk nettsiden <FontAwesomeIcon icon={faExternalLink} size={14} color={colors.primary} />
+            {t['settings.sponsorVisitWebsite']} <FontAwesomeIcon icon={faExternalLink} size={14} color={colors.primary} />
           </Text>
         </View>
       </TouchableOpacity>

--- a/lib/i18n/translations/en.ts
+++ b/lib/i18n/translations/en.ts
@@ -492,4 +492,128 @@ export const en: TranslationKeys = {
 
   'confirmRemove.message': 'Confirm removal of sight marks',
   'confirmRemove.yes': 'Yes',
+
+  // Common additions
+  'common.advanced': 'Advanced',
+  'common.favourite': 'Favourite',
+  'common.noResults': 'No results',
+  'common.chooseOption': 'Choose an option',
+
+  // Settings screen
+  'settings.title': 'Settings',
+  'settings.logout': 'Log out',
+  'settings.loggingOut': 'Logging out...',
+  'settings.deleteAccount': 'Delete account',
+  'settings.deletingAccount': 'Deleting account...',
+  'settings.deleteDescription':
+    'When you delete your account, all your data will be permanently removed. This includes training sessions, equipment and profile information. This action cannot be undone.',
+  'settings.confirmDeleteTitle': 'Confirm account deletion',
+  'settings.confirmDeleteMessage':
+    'Are you sure you want to delete your account? All your data will be permanently removed, including training sessions, equipment and profile information. This action cannot be undone.',
+  'settings.confirmDeleteYes': 'Yes, delete account',
+  'settings.deleteError': 'Could not delete account. Please try again.',
+
+  // Settings — account section
+  'settings.accountTitle': 'Account',
+  'settings.accountNameLabel': 'Name',
+  'settings.accountEmailLabel': 'Email',
+  'settings.accountClubLabel': 'Club',
+  'settings.accountArcherNumberLabel': 'Archer number',
+
+  // Settings — public profile section
+  'settings.publicProfileTitle': 'Public profile',
+  'settings.publicProfileIntro': 'Make your profile searchable to other users. You choose what you want to share.',
+  'settings.makeProfilePublic': 'Make my profile public',
+  'settings.choosePublicFields': 'Choose what is shown publicly:',
+  'settings.publicName': 'Name',
+  'settings.publicClub': 'Club',
+  'settings.publicArcherNumber': 'Archer number',
+  'settings.publicStats': 'Statistics (total arrows and average score)',
+  'settings.publicAchievements': 'Achievements (number of unlocked achievements)',
+  'settings.publicSaved': 'Settings saved',
+  'settings.publicSaveError': 'Could not save settings',
+
+  // Settings — privacy section
+  'settings.privacyTitle': 'Privacy and data security',
+  'settings.privacyIntro': 'Your data is safe with us. We take privacy seriously and commit to protecting your information.',
+  'settings.privacyNeverSharedTitle': 'Never shared or sold',
+  'settings.privacyNeverSharedDesc': 'We never share or sell your data to third parties. Your information remains private.',
+  'settings.privacyAppOnlyTitle': 'Used for app operation only',
+  'settings.privacyAppOnlyDesc': 'We only use your data to operate the app and give you the best user experience.',
+  'settings.privacyYourControlTitle': 'Your control',
+  'settings.privacyYourControlDesc': 'You can delete your account and all associated data at any time.',
+  'settings.privacySecureStorageTitle': 'Secure storage',
+  'settings.privacySecureStorageDesc': 'All data is encrypted and stored securely in accordance with modern security standards.',
+  'settings.privacyAnalyticsTitle': 'Analytics and improvement',
+  'settings.privacyAnalyticsPre': 'We use',
+  'settings.privacyAnalyticsMid': 'to understand how the app is used and improve the user experience. Read more in',
+  'settings.privacyMSPrivacy': "Microsoft's privacy statement",
+  'settings.privacyFooter': 'If you have questions about how we handle your data, please feel free to contact us.',
+
+  // Settings — sponsor card
+  'settings.sponsorLabel': 'Sponsored by',
+  'settings.sponsorVisitWebsite': 'Visit website',
+
+  // Bow form
+  'bowForm.editTitle': 'Edit bow',
+  'bowForm.newTitle': 'New bow',
+  'bowForm.nameLabel': 'Bow name',
+  'bowForm.nameRequired': 'Bow name is required',
+  'bowForm.typeLabel': 'Bow type',
+  'bowForm.handPlaceholder': 'Choose hand',
+  'bowForm.drawWeight': 'Draw weight (lbs)',
+  'bowForm.bowLength': 'Length (inches)',
+  'bowForm.sightMarksSection': 'Sight marks',
+  'bowForm.eyeToNock': 'Eye to nock (cm)',
+  'bowForm.eyeToSight': 'Eye to sight (cm)',
+  'bowForm.notesPlaceholder': 'e.g. Special settings or adjustments',
+  'bowForm.deleteTitle': 'Delete bow',
+  'bowForm.deleteMessage': 'Delete bow "{name}"?',
+  'bowForm.maxBowsError': 'You cannot have more than 5 bows',
+  'bowForm.saveError': 'Could not save bow',
+  'bowForm.deleteError': 'Could not delete bow',
+
+  // Arrow form
+  'arrowForm.editTitle': 'Edit arrow set',
+  'arrowForm.newTitle': 'New arrow set',
+  'arrowForm.nameLabel': 'Arrow set name',
+  'arrowForm.nameHelpText': 'e.g. Carbon X23',
+  'arrowForm.nameInfo': '(required)',
+  'arrowForm.arrowCountHelpText': 'e.g. 12',
+  'arrowForm.grainSuffix': '(grain)',
+  'arrowForm.mmSuffix': '(mm)',
+  'arrowForm.lengthHelpText': 'e.g. 31',
+  'arrowForm.weightHelpText': 'e.g. 400',
+  'arrowForm.spineHelpText': 'e.g. 500',
+  'arrowForm.diameterHelpText': 'e.g. 5.2',
+  'arrowForm.pointTypeHelpText': 'e.g. Bullet',
+  'arrowForm.pointWeightHelpText': 'e.g. 100',
+  'arrowForm.vanesHelpText': 'e.g. Bohning X Vanes',
+  'arrowForm.nockHelpText': 'e.g. Easton G Nock',
+  'arrowForm.notesPlaceholder': 'Extra information about the arrow set',
+  'arrowForm.deleteTitle': 'Delete arrow set',
+  'arrowForm.deleteMessage': 'Delete arrow set "{name}"?',
+  'arrowForm.nameRequired': 'Name is required',
+  'arrowForm.deleteError': 'Could not delete arrow set',
+  'arrowForm.saveError': 'Could not save arrow set',
+
+  // Profile form
+  'profileForm.nameLabel': 'Name',
+  'profileForm.nameHelpText': 'Your full name',
+  'profileForm.nameRequired': 'Name is required',
+  'profileForm.clubLabel': 'Club',
+  'profileForm.clubPlaceholder': 'Choose a club',
+  'profileForm.noClub': 'None / not affiliated',
+  'profileForm.archerNumberLabel': 'Archer no.',
+  'profileForm.archerNumberHelpText': 'Your archer number',
+
+  // Offline banner
+  'offline.disconnected': 'Offline — changes will sync when connected',
+  'offline.syncing': 'Working...',
+  'offline.queued': '{count} queued — tap to sync',
+
+  // Update required screen
+  'update.title': 'Update required',
+  'update.button': 'Update now',
+  'update.subtext': 'You must update the app to continue using Bueboka',
 };

--- a/lib/i18n/translations/no.ts
+++ b/lib/i18n/translations/no.ts
@@ -492,4 +492,129 @@ export const no: TranslationKeys = {
 
   'confirmRemove.message': 'Bekreft fjerning av siktemerker',
   'confirmRemove.yes': 'Ja',
+
+  // Common additions
+  'common.advanced': 'Avansert',
+  'common.favourite': 'Favoritt',
+  'common.noResults': 'Ingen treff',
+  'common.chooseOption': 'Velg et alternativ',
+
+  // Settings screen
+  'settings.title': 'Innstillinger',
+  'settings.logout': 'Logg ut',
+  'settings.loggingOut': 'Logger ut...',
+  'settings.deleteAccount': 'Slett konto',
+  'settings.deletingAccount': 'Sletter konto...',
+  'settings.deleteDescription':
+    'Når du sletter kontoen din, vil alle dine data bli permanent fjernet. Dette inkluderer treningsøkter, utstyr og profilinformasjon. Denne handlingen kan ikke angres.',
+  'settings.confirmDeleteTitle': 'Bekreft sletting av konto',
+  'settings.confirmDeleteMessage':
+    'Er du sikker på at du vil slette kontoen din? Alle dine data vil bli permanent fjernet, inkludert treningsøkter, utstyr og profilinformasjon. Denne handlingen kan ikke angres.',
+  'settings.confirmDeleteYes': 'Ja, slett konto',
+  'settings.deleteError': 'Kunne ikke slette konto. Prøv igjen.',
+
+  // Settings — account section
+  'settings.accountTitle': 'Konto',
+  'settings.accountNameLabel': 'Navn',
+  'settings.accountEmailLabel': 'E-post',
+  'settings.accountClubLabel': 'Klubb',
+  'settings.accountArcherNumberLabel': 'Skytternummer',
+
+  // Settings — public profile section
+  'settings.publicProfileTitle': 'Offentlig profil',
+  'settings.publicProfileIntro': 'Gjør profilen din søkbar for andre brukere. Du velger selv hva du ønsker å dele.',
+  'settings.makeProfilePublic': 'Gjør profilen min offentlig',
+  'settings.choosePublicFields': 'Velg hva som vises offentlig:',
+  'settings.publicName': 'Navn',
+  'settings.publicClub': 'Klubb',
+  'settings.publicArcherNumber': 'Skytternummer',
+  'settings.publicStats': 'Statistikk (totalt antall piler og snittpoeng)',
+  'settings.publicAchievements': 'Prestasjoner (antall oppnådde prestasjoner)',
+  'settings.publicSaved': 'Innstillinger lagret',
+  'settings.publicSaveError': 'Kunne ikke lagre innstillinger',
+
+  // Settings — privacy section
+  'settings.privacyTitle': 'Personvern og datasikkerhet',
+  'settings.privacyIntro': 'Dine data er trygge hos oss. Vi tar personvern på alvor og forplikter oss til å beskytte informasjonen din.',
+  'settings.privacyNeverSharedTitle': 'Aldri delt eller solgt',
+  'settings.privacyNeverSharedDesc': 'Vi deler eller selger aldri dataene dine til tredjeparter. Din informasjon forblir privat.',
+  'settings.privacyAppOnlyTitle': 'Kun til appens drift',
+  'settings.privacyAppOnlyDesc': 'Vi bruker kun dataene dine til å drive appen og gi deg den beste brukeropplevelsen.',
+  'settings.privacyYourControlTitle': 'Din kontroll',
+  'settings.privacyYourControlDesc': 'Du kan når som helst slette kontoen din og all tilhørende data.',
+  'settings.privacySecureStorageTitle': 'Sikker lagring',
+  'settings.privacySecureStorageDesc': 'All data krypteres og lagres sikkert i samsvar med moderne sikkerhetsstandarder.',
+  'settings.privacyAnalyticsTitle': 'Analyse og forbedring',
+  'settings.privacyAnalyticsPre': 'Vi bruker',
+  'settings.privacyAnalyticsMid':
+    'for å forstå hvordan appen brukes og forbedre brukeropplevelsen. Les mer i',
+  'settings.privacyMSPrivacy': 'Microsofts personvernerklæring',
+  'settings.privacyFooter': 'Hvis du har spørsmål om hvordan vi håndterer dataene dine, ta gjerne kontakt med oss.',
+
+  // Settings — sponsor card
+  'settings.sponsorLabel': 'Sponset av',
+  'settings.sponsorVisitWebsite': 'Besøk nettsiden',
+
+  // Bow form
+  'bowForm.editTitle': 'Rediger bue',
+  'bowForm.newTitle': 'Ny bue',
+  'bowForm.nameLabel': 'Navn på bue',
+  'bowForm.nameRequired': 'Du må fylle inn navn på bue',
+  'bowForm.typeLabel': 'Buetype',
+  'bowForm.handPlaceholder': 'Velg hånd',
+  'bowForm.drawWeight': 'Styrke (pund)',
+  'bowForm.bowLength': 'Lengde (tommer)',
+  'bowForm.sightMarksSection': 'Siktemerke',
+  'bowForm.eyeToNock': 'Øye til nock (cm)',
+  'bowForm.eyeToSight': 'Øye til sikte (cm)',
+  'bowForm.notesPlaceholder': 'F.eks. Spesielle innstillinger eller justeringer',
+  'bowForm.deleteTitle': 'Slett bue',
+  'bowForm.deleteMessage': 'Vil du slette buen "{name}"?',
+  'bowForm.maxBowsError': 'Du kan ikke ha mer enn 5 buer',
+  'bowForm.saveError': 'Kunne ikke lagre bue',
+  'bowForm.deleteError': 'Kunne ikke slette bue',
+
+  // Arrow form
+  'arrowForm.editTitle': 'Rediger pilsett',
+  'arrowForm.newTitle': 'Nytt pilsett',
+  'arrowForm.nameLabel': 'Navn på pilsett',
+  'arrowForm.nameHelpText': 'F.eks. Carbon X23',
+  'arrowForm.nameInfo': '(obligatorisk)',
+  'arrowForm.arrowCountHelpText': 'F.eks. 12',
+  'arrowForm.grainSuffix': '(grain)',
+  'arrowForm.mmSuffix': '(mm)',
+  'arrowForm.lengthHelpText': 'F.eks. 31',
+  'arrowForm.weightHelpText': 'F.eks. 400',
+  'arrowForm.spineHelpText': 'F.eks. 500',
+  'arrowForm.diameterHelpText': 'F.eks. 5.2',
+  'arrowForm.pointTypeHelpText': 'F.eks. Bullet',
+  'arrowForm.pointWeightHelpText': 'F.eks. 100',
+  'arrowForm.vanesHelpText': 'F.eks. Bohning X Vanes',
+  'arrowForm.nockHelpText': 'F.eks. Easton G Nock',
+  'arrowForm.notesPlaceholder': 'Ekstra informasjon om pilsettet',
+  'arrowForm.deleteTitle': 'Slett pilsett',
+  'arrowForm.deleteMessage': 'Vil du slette pilsettet "{name}"?',
+  'arrowForm.nameRequired': 'Navn er påkrevd',
+  'arrowForm.deleteError': 'Kunne ikke slette pilsett',
+  'arrowForm.saveError': 'Kunne ikke lagre pilsett',
+
+  // Profile form
+  'profileForm.nameLabel': 'Navn',
+  'profileForm.nameHelpText': 'Ditt fulle navn',
+  'profileForm.nameRequired': 'Navn er påkrevd',
+  'profileForm.clubLabel': 'Klubb',
+  'profileForm.clubPlaceholder': 'Velg en klubb',
+  'profileForm.noClub': 'Ingen / ikke tilknyttet',
+  'profileForm.archerNumberLabel': 'Skytternr',
+  'profileForm.archerNumberHelpText': 'Ditt skytternummer',
+
+  // Offline banner
+  'offline.disconnected': 'Frakoblet — endringer synkroniseres når du er tilkoblet',
+  'offline.syncing': 'Jobber...',
+  'offline.queued': '{count} i kø – trykk for å synkronisere',
+
+  // Update required screen
+  'update.title': 'Oppdatering påkrevd',
+  'update.button': 'Oppdater nå',
+  'update.subtext': 'Du må oppdatere appen for å fortsette å bruke Bueboka',
 };

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -536,4 +536,126 @@ export interface TranslationKeys {
   // Confirm remove marks
   'confirmRemove.message': string;
   'confirmRemove.yes': string;
+
+  // Common additions
+  'common.advanced': string;
+  'common.favourite': string;
+  'common.noResults': string;
+  'common.chooseOption': string;
+
+  // Settings screen
+  'settings.title': string;
+  'settings.logout': string;
+  'settings.loggingOut': string;
+  'settings.deleteAccount': string;
+  'settings.deletingAccount': string;
+  'settings.deleteDescription': string;
+  'settings.confirmDeleteTitle': string;
+  'settings.confirmDeleteMessage': string;
+  'settings.confirmDeleteYes': string;
+  'settings.deleteError': string;
+
+  // Settings — account section
+  'settings.accountTitle': string;
+  'settings.accountNameLabel': string;
+  'settings.accountEmailLabel': string;
+  'settings.accountClubLabel': string;
+  'settings.accountArcherNumberLabel': string;
+
+  // Settings — public profile section
+  'settings.publicProfileTitle': string;
+  'settings.publicProfileIntro': string;
+  'settings.makeProfilePublic': string;
+  'settings.choosePublicFields': string;
+  'settings.publicName': string;
+  'settings.publicClub': string;
+  'settings.publicArcherNumber': string;
+  'settings.publicStats': string;
+  'settings.publicAchievements': string;
+  'settings.publicSaved': string;
+  'settings.publicSaveError': string;
+
+  // Settings — privacy section
+  'settings.privacyTitle': string;
+  'settings.privacyIntro': string;
+  'settings.privacyNeverSharedTitle': string;
+  'settings.privacyNeverSharedDesc': string;
+  'settings.privacyAppOnlyTitle': string;
+  'settings.privacyAppOnlyDesc': string;
+  'settings.privacyYourControlTitle': string;
+  'settings.privacyYourControlDesc': string;
+  'settings.privacySecureStorageTitle': string;
+  'settings.privacySecureStorageDesc': string;
+  'settings.privacyAnalyticsTitle': string;
+  'settings.privacyAnalyticsPre': string;
+  'settings.privacyAnalyticsMid': string;
+  'settings.privacyMSPrivacy': string;
+  'settings.privacyFooter': string;
+
+  // Settings — sponsor card
+  'settings.sponsorLabel': string;
+  'settings.sponsorVisitWebsite': string;
+
+  // Bow form
+  'bowForm.editTitle': string;
+  'bowForm.newTitle': string;
+  'bowForm.nameLabel': string;
+  'bowForm.nameRequired': string;
+  'bowForm.typeLabel': string;
+  'bowForm.handPlaceholder': string;
+  'bowForm.drawWeight': string;
+  'bowForm.bowLength': string;
+  'bowForm.sightMarksSection': string;
+  'bowForm.eyeToNock': string;
+  'bowForm.eyeToSight': string;
+  'bowForm.notesPlaceholder': string;
+  'bowForm.deleteTitle': string;
+  'bowForm.deleteMessage': string;
+  'bowForm.maxBowsError': string;
+  'bowForm.saveError': string;
+  'bowForm.deleteError': string;
+
+  // Arrow form
+  'arrowForm.editTitle': string;
+  'arrowForm.newTitle': string;
+  'arrowForm.nameLabel': string;
+  'arrowForm.nameHelpText': string;
+  'arrowForm.nameInfo': string;
+  'arrowForm.arrowCountHelpText': string;
+  'arrowForm.grainSuffix': string;
+  'arrowForm.mmSuffix': string;
+  'arrowForm.lengthHelpText': string;
+  'arrowForm.weightHelpText': string;
+  'arrowForm.spineHelpText': string;
+  'arrowForm.diameterHelpText': string;
+  'arrowForm.pointTypeHelpText': string;
+  'arrowForm.pointWeightHelpText': string;
+  'arrowForm.vanesHelpText': string;
+  'arrowForm.nockHelpText': string;
+  'arrowForm.notesPlaceholder': string;
+  'arrowForm.deleteTitle': string;
+  'arrowForm.deleteMessage': string;
+  'arrowForm.nameRequired': string;
+  'arrowForm.deleteError': string;
+  'arrowForm.saveError': string;
+
+  // Profile form
+  'profileForm.nameLabel': string;
+  'profileForm.nameHelpText': string;
+  'profileForm.nameRequired': string;
+  'profileForm.clubLabel': string;
+  'profileForm.clubPlaceholder': string;
+  'profileForm.noClub': string;
+  'profileForm.archerNumberLabel': string;
+  'profileForm.archerNumberHelpText': string;
+
+  // Offline banner
+  'offline.disconnected': string;
+  'offline.syncing': string;
+  'offline.queued': string;
+
+  // Update required screen
+  'update.title': string;
+  'update.button': string;
+  'update.subtext': string;
 }


### PR DESCRIPTION
## Summary

- **Settings screen** — title, logout, delete-account flow, confirm modal
- **Settings components** — AccountSection, PublicProfileSection, PrivacySection (privacy items converted from module-level array to typed constant), SponsorCard
- **Equipment forms** — BowForm and ArrowForm fully translated; reuses existing `bowDetails.*` / `arrowDetails.*` / `bowType.*` / `arrowMaterial.*` keys where semantically correct; `{name}` template replacement for delete-confirm dialogs
- **ProfileForm** — `CLUB_OPTIONS` moved inside component so `t` is available at render time
- **Common components** — OfflineBanner, UpdateRequired, Input, Select (`common.chooseOption` fallback + `common.noResults`), Textarea
- **~90 new keys** added to `types.ts`, `no.ts`, `en.ts` across `settings.*`, `bowForm.*`, `arrowForm.*`, `profileForm.*`, `offline.*`, `update.*`, and extensions to `common.*`

## What's not in this PR

`services/api/errors.ts` messages remain Norwegian — the service layer has no access to React context. Translating them requires mapping `AppError.code` → translation key at each call site, tracked as a follow-up.

## Test plan

- [ ] Switch language to English, open Settings — all labels, section titles, and logout/delete flow use English
- [ ] Open bow form (new + edit) — all field labels, bow type options, advanced section, sight marks section, save/cancel/delete in English
- [ ] Open arrow form (new + edit) — same coverage; delete confirm shows arrow set name
- [ ] Open profile form — club placeholder, labels, validation error in English
- [ ] Go offline — banner reads "Offline — changes will sync when connected"
- [ ] 402 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)