### PR TITLE
feat(i18n): add language picker to intro screen

### DIFF
--- a/app/intro.tsx
+++ b/app/intro.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/common';
 import { colors } from '@/styles/colors';
 import { useTranslation } from '@/contexts';
 import { styles } from '@/components/intro/IntroStyles';
+import IntroLanguagePicker from '@/components/intro/IntroLanguagePicker';
 
 export const INTRO_SEEN_KEY = 'bueboka_has_seen_intro';
 
@@ -30,6 +31,8 @@ export default function IntroScreen() {
 
       <SafeAreaView style={styles.safeArea}>
         <View style={styles.container}>
+          <IntroLanguagePicker />
+
           {/* Logo */}
           <View style={styles.logoSection}>
             <View style={styles.logoWrapper}>

--- a/components/intro/IntroLanguagePicker.tsx
+++ b/components/intro/IntroLanguagePicker.tsx
@@ -1,0 +1,32 @@
+import { Text, TouchableOpacity, View } from 'react-native';
+import { useTranslation } from '@/contexts';
+import type { Locale } from '@/lib/i18n';
+import { introLanguagePickerStyles as s } from './IntroLanguagePickerStyles';
+
+const OPTIONS: { code: Locale; flag: string }[] = [
+  { code: 'no', flag: '🇳🇴' },
+  { code: 'en', flag: '🇬🇧' },
+];
+
+export default function IntroLanguagePicker() {
+  const { locale, setLanguage, t } = useTranslation();
+
+  return (
+    <View style={s.container} accessibilityLabel={t['intro.chooseLanguage']} accessibilityRole="radiogroup">
+      {OPTIONS.map((opt) => {
+        const active = locale === opt.code;
+        return (
+          <TouchableOpacity
+            key={opt.code}
+            onPress={() => void setLanguage(opt.code)}
+            style={[s.pill, active && s.pillActive]}
+            accessibilityRole="radio"
+            accessibilityState={{ selected: active }}
+          >
+            <Text style={s.flag}>{opt.flag}</Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+}

--- a/components/intro/IntroLanguagePickerStyles.ts
+++ b/components/intro/IntroLanguagePickerStyles.ts
@@ -1,0 +1,25 @@
+import { StyleSheet } from 'react-native';
+import { colors } from '@/styles/colors';
+
+export const introLanguagePickerStyles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignSelf: 'flex-end',
+    gap: 8,
+  },
+  pill: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: colors.white20,
+    backgroundColor: colors.white10,
+  },
+  pillActive: {
+    borderColor: colors.white50,
+    backgroundColor: colors.white25,
+  },
+  flag: {
+    fontSize: 20,
+  },
+});

--- a/components/intro/__tests__/IntroLanguagePicker.test.tsx
+++ b/components/intro/__tests__/IntroLanguagePicker.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import IntroLanguagePicker from '../IntroLanguagePicker';
+
+const mockSetLanguage = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('@/contexts', () => {
+  const { no } = require('@/lib/i18n/translations/no');
+  let currentLocale = 'no';
+  return {
+    useTranslation: () => ({
+      locale: currentLocale,
+      t: no,
+      setLanguage: mockSetLanguage,
+      isLoaded: true,
+    }),
+    __setTestLocale: (l: string) => {
+      currentLocale = l;
+    },
+  };
+});
+
+const { __setTestLocale } = require('@/contexts') as { __setTestLocale: (l: string) => void };
+
+describe('IntroLanguagePicker', () => {
+  beforeEach(() => {
+    mockSetLanguage.mockClear();
+    __setTestLocale('no');
+  });
+
+  it('renders two flag options', () => {
+    render(<IntroLanguagePicker />);
+    const buttons = screen.getAllByRole('radio');
+    expect(buttons).toHaveLength(2);
+  });
+
+  it('marks the Norwegian option as selected when locale is "no"', () => {
+    render(<IntroLanguagePicker />);
+    const buttons = screen.getAllByRole('radio');
+    expect(buttons[0].props.accessibilityState).toEqual({ selected: true });
+    expect(buttons[1].props.accessibilityState).toEqual({ selected: false });
+  });
+
+  it('marks the English option as selected when locale is "en"', () => {
+    __setTestLocale('en');
+    render(<IntroLanguagePicker />);
+    const buttons = screen.getAllByRole('radio');
+    expect(buttons[0].props.accessibilityState).toEqual({ selected: false });
+    expect(buttons[1].props.accessibilityState).toEqual({ selected: true });
+  });
+
+  it('calls setLanguage("en") when the English flag is tapped', () => {
+    render(<IntroLanguagePicker />);
+    const buttons = screen.getAllByRole('radio');
+    fireEvent.press(buttons[1]);
+    expect(mockSetLanguage).toHaveBeenCalledWith('en');
+  });
+
+  it('calls setLanguage("no") when the Norwegian flag is tapped', () => {
+    __setTestLocale('en');
+    render(<IntroLanguagePicker />);
+    const buttons = screen.getAllByRole('radio');
+    fireEvent.press(buttons[0]);
+    expect(mockSetLanguage).toHaveBeenCalledWith('no');
+  });
+
+  it('has an accessible container with a language label', () => {
+    render(<IntroLanguagePicker />);
+    expect(screen.getByLabelText('Velg språk')).toBeTruthy();
+  });
+});

--- a/lib/i18n/translations/en.ts
+++ b/lib/i18n/translations/en.ts
@@ -14,6 +14,7 @@ export const en: TranslationKeys = {
   'intro.body':
     'Log practices and competitions, track your sight marks and follow your progress over time. Everything you need to become a better archer.',
   'intro.getStarted': 'Get started',
+  'intro.chooseLanguage': 'Choose language',
 
   'auth.emailLabel': 'Email',
   'auth.passwordLabel': 'Password',

--- a/lib/i18n/translations/no.ts
+++ b/lib/i18n/translations/no.ts
@@ -14,6 +14,7 @@ export const no: TranslationKeys = {
   'intro.body':
     'Logg treninger og konkurranser, spor siktmerkene dine og følg fremgangen over tid. Alt du trenger for å bli en bedre bueskytter.',
   'intro.getStarted': 'Kom i gang',
+  'intro.chooseLanguage': 'Velg språk',
 
   'auth.emailLabel': 'E-post',
   'auth.passwordLabel': 'Passord',

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -18,6 +18,7 @@ export interface TranslationKeys {
   'intro.titleLine2': string;
   'intro.body': string;
   'intro.getStarted': string;
+  'intro.chooseLanguage': string;
 
   // Auth screen
   'auth.emailLabel': string;


### PR DESCRIPTION
## Summary

- Adds a compact flag-pill language toggle (🇳🇴 / 🇬🇧) to the top-right of the intro screen
- Saves the language choice to AsyncStorage only — no database write for unauthenticated users
- After login, the existing `LanguageProvider` reconciliation syncs the local preference to the server automatically
- Zero backend or database changes required

## Test plan

- [x] Unit tests for `IntroLanguagePicker` (6 tests covering rendering, selection state, `setLanguage` calls, and accessibility)
- [ ] Manual: launch app fresh (clear AsyncStorage) → verify picker appears on intro screen
- [ ] Manual: tap English flag → verify intro screen text switches to English immediately
- [ ] Manual: tap "Get started" → verify auth screen is also in English
- [ ] Manual: register/login → verify language preference syncs to the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)