### PR TITLE
fix(ci): use EXPO_GOOGLE_SERVICE_ACCOUNT_KEY for Play Store submissions

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -61,8 +61,7 @@
     "preview": {
       "android": {
         "track": "internal",
-        "releaseStatus": "completed",
-        "serviceAccountKeyPath": "${process.env.GOOGLE_SERVICE_ACCOUNT_PATH}"
+        "releaseStatus": "completed"
       },
       "ios": {
         "ascAppId": "6448108838"
@@ -71,8 +70,7 @@
     "production": {
       "android": {
         "track": "production",
-        "releaseStatus": "completed",
-        "serviceAccountKeyPath": "${process.env.GOOGLE_SERVICE_ACCOUNT_PATH}"
+        "releaseStatus": "completed"
       },
       "ios": {
         "ascAppId": "6448108838"


### PR DESCRIPTION
## Summary
- Remove `serviceAccountKeyPath` from eas.json submit config (both preview and production)
- EAS CLI auto-detects the `EXPO_GOOGLE_SERVICE_ACCOUNT_KEY` env var for Google Play submissions
- Fixes credential resolution failure in EAS workflow submit jobs

## Setup required
Add `EXPO_GOOGLE_SERVICE_ACCOUNT_KEY` as a secret on expo.dev with the raw JSON content of the service account key.

## Test plan
- [x] Verify `EXPO_GOOGLE_SERVICE_ACCOUNT_KEY` secret is created on expo.dev
- [x] Trigger a build+submit workflow and confirm Play Store submission succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)