### PR TITLE
fix(home): show only one alert on avatar upload/remove failure

### DIFF
--- a/app/(tabs)/home/index.tsx
+++ b/app/(tabs)/home/index.tsx
@@ -21,7 +21,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight';
 import { faTrophy } from '@fortawesome/free-solid-svg-icons/faTrophy';
 import ProfileImageManager from '@/components/home/profile/ProfileImageManager';
-import { AppError } from '@/services';
 import CreateCompetitionForm from '@/components/practice/competitionForm/CreateCompetitionForm';
 import { faUserGroup } from '@fortawesome/free-solid-svg-icons';
 import { PracticeDetailsModal } from '@/components/practice/practiceDetailsModal';
@@ -97,23 +96,13 @@ export default function HomeScreen() {
   };
 
   async function handleAvatarUpload(uri: string) {
-    try {
-      await userRepository.updateAvatar(uri);
-      await refreshUser();
-    } catch (err) {
-      const message = err instanceof AppError ? err.message : t['home.uploadAvatarError'];
-      Alert.alert(t['common.error'], message);
-    }
+    await userRepository.updateAvatar(uri);
+    await refreshUser();
   }
 
   async function handleAvatarRemove() {
-    try {
-      await userRepository.removeAvatar();
-      await refreshUser();
-    } catch (err) {
-      const message = err instanceof AppError ? err.message : t['home.removeAvatarError'];
-      Alert.alert(t['common.error'], message);
-    }
+    await userRepository.removeAvatar();
+    await refreshUser();
   }
 
   if (!user) {


### PR DESCRIPTION
## Summary
- **Bug:** Uploading a profile image on mobile showed both a success and an error alert simultaneously
- **Cause:** `handleAvatarUpload` and `handleAvatarRemove` in `home/index.tsx` caught errors and displayed their own alert without re-throwing, so `ProfileImageManager` never saw the failure and showed the success alert too
- **Fix:** Removed the duplicate try/catch from both handlers, letting errors propagate to `ProfileImageManager` which already has proper success/error handling

## Test plan
- [ ] Upload a profile image on mobile — should show only the success alert
- [ ] Simulate a failed upload (e.g. airplane mode) — should show only the error alert
- [ ] Remove a profile image — verify single success alert
- [ ] Verify web upload still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)