### PR TITLE
ci: add EAS preview build workflow for dev branch

### DIFF
--- a/.eas/workflows/build-and-submit-preview.yml
+++ b/.eas/workflows/build-and-submit-preview.yml
@@ -1,0 +1,51 @@
+name: Build, Submit, and Sync Preview Version
+
+on:
+  push:
+    branches: [dev]
+
+jobs:
+  build_ios:
+    name: Build iOS Preview
+    type: build
+    params:
+      platform: ios
+      profile: preview
+
+  build_android:
+    name: Build Android Preview
+    type: build
+    params:
+      platform: android
+      profile: preview
+
+  submit_ios:
+    name: Submit to TestFlight
+    type: submit
+    needs: [build_ios]
+    params:
+      build_id: ${{ needs.build_ios.outputs.build_id }}
+      profile: preview
+
+  submit_android:
+    name: Submit to Google Play Internal
+    type: submit
+    needs: [build_android]
+    params:
+      build_id: ${{ needs.build_android.outputs.build_id }}
+      profile: preview
+
+  sync_version:
+    name: Sync preview version to API
+    needs: [submit_ios, submit_android]
+    env:
+      BUEBOKA_API_URL: ${{ env.BUEBOKA_API_URL }}
+      APP_ADMIN_API_KEY: ${{ env.APP_ADMIN_API_KEY }}
+      APP_VERSION: ${{ needs.build_ios.outputs.app_version }}
+    steps:
+      - name: Update preview app version in database
+        run: |
+          curl -f -X PUT "$BUEBOKA_API_URL/api/app/version" \
+            -H "Authorization: Bearer $APP_ADMIN_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"currentVersion\": \"$APP_VERSION\"}"


### PR DESCRIPTION
## Summary
- Adds a new EAS workflow that triggers on pushes to `dev` (i.e., merged PRs)
- Builds iOS and Android using the `preview` profile, submits to TestFlight and Google Play internal track
- Syncs the app version to the API after successful submission
- Mirrors the production workflow structure from `build-and-submit.yml`

## Test plan
- [ ] Merge a PR into `dev` and verify the workflow triggers
- [ ] Confirm iOS build uses the `preview` profile and submits to TestFlight
- [ ] Confirm Android build submits to the internal track
- [ ] Verify version sync step completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)