### PR TITLE
fix: avatar upload on mobile devices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,14 @@ Domain discovery first — understand the ubiquitous language (see `docs/skills/
 
 ## Git workflow
 
+### Branching strategy
+
+- **`dev`** is the default branch. All feature and fix branches are created from `dev` and merged back into `dev` via pull request.
+- **`main`** is the production branch. When a new version is ready to ship to users, `dev` is merged into `main` via pull request.
+- Merging into `dev` triggers the **preview** EAS workflow — builds and submits to TestFlight (iOS) and Google Play internal track (Android) for beta testing.
+- Merging into `main` triggers the **production** EAS workflow — builds and submits to the App Store and Google Play production track.
+- Branch naming: `feat/<name>`, `fix/<name>`, `refactor/<name>`, `ci/<name>`, etc.
+
 ### Commit messages — Conventional Commits
 
 All commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec. Format:

--- a/components/home/profile/ProfileImageManager.tsx
+++ b/components/home/profile/ProfileImageManager.tsx
@@ -57,7 +57,7 @@ export default function ProfileImageManager({ userName, avatarUrl, onUpload, onR
     try {
       setIsUploading(true);
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: ['images'],
         quality: 0.85,
         allowsEditing: true,
         aspect: [1, 1],

--- a/services/api/authFetch.ts
+++ b/services/api/authFetch.ts
@@ -39,8 +39,6 @@ export async function authFetch<T = any>(endpoint: string, options: RequestInit 
 
     return { data: (data ?? null) as T };
   } catch (error: any) {
-    // 401/403 and network failures are expected and handled by callers — don't capture them.
-    // Everything else is unexpected and should be tracked in Sentry.
     const status = error?.status ?? error?.response?.status;
     const isExpected = status === 401 || status === 403 || error?.message?.includes('Network');
     if (!isExpected) {

--- a/services/api/uploadAvatar.ts
+++ b/services/api/uploadAvatar.ts
@@ -1,0 +1,32 @@
+import { File as ExpoFile } from 'expo-file-system';
+import { authFetchClient as client } from '@/services/api/authFetch';
+import { Platform } from 'react-native';
+import { User } from '@/types';
+
+async function fileToBase64DataUri(uri: string): Promise<string> {
+  if (Platform.OS === 'web') {
+    const response = await fetch(uri);
+    const blob = await response.blob();
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsDataURL(blob);
+    });
+  }
+
+  const file = new ExpoFile(uri);
+  const buffer = await file.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return `data:image/jpeg;base64,${btoa(binary)}`;
+}
+
+export async function uploadAvatar(imageUri: string): Promise<User> {
+  const dataUri = await fileToBase64DataUri(imageUri);
+  const response = await client.patch<User>('/users', { image: dataUri });
+  return response.data;
+}

--- a/services/repositories/__tests__/userRepository.test.ts
+++ b/services/repositories/__tests__/userRepository.test.ts
@@ -1,6 +1,7 @@
 import { AxiosError, AxiosHeaders } from 'axios';
 import { userRepository } from '@/services';
 import { authFetchClient } from '@/services/api/authFetch';
+import { uploadAvatar } from '@/services/api/uploadAvatar';
 import { AppError } from '@/services/api/errors';
 import { User } from '@/types';
 
@@ -12,6 +13,10 @@ jest.mock('@/services/api/authFetch', () => ({
     patch: jest.fn(),
     delete: jest.fn(),
   },
+}));
+
+jest.mock('@/services/api/uploadAvatar', () => ({
+  uploadAvatar: jest.fn(),
 }));
 
 jest.mock('@sentry/react-native', () => ({
@@ -48,6 +53,7 @@ const fakeUser: User = {
   publicStats: false,
   publicSkytternr: false,
   publicAchievements: false,
+  locale: 'no',
   createdAt: '2024-01-01T00:00:00.000Z',
   updatedAt: '2024-01-01T00:00:00.000Z',
 };
@@ -123,18 +129,21 @@ describe('userRepository.updateProfile', () => {
 
 // ── updateAvatar ──────────────────────────────────────────────────────────────
 
+const mockUploadAvatar = uploadAvatar as jest.MockedFunction<typeof uploadAvatar>;
+
 describe('userRepository.updateAvatar', () => {
-  it('sends a multipart/form-data PATCH to /users with the image file', async () => {
-    mockClient.patch.mockResolvedValueOnce({ data: { ...fakeUser, image: 'https://cdn.example.com/avatar.jpg' } });
+  it('delegates to uploadAvatar and returns the updated user', async () => {
+    const updatedUser = { ...fakeUser, image: 'https://cdn.example.com/avatar.jpg' };
+    mockUploadAvatar.mockResolvedValueOnce(updatedUser as User);
 
     const result = await userRepository.updateAvatar('file:///tmp/avatar.jpg');
 
     expect(result.image).toBe('https://cdn.example.com/avatar.jpg');
-    expect(mockClient.patch).toHaveBeenCalledWith('/users', expect.any(FormData));
+    expect(mockUploadAvatar).toHaveBeenCalledWith('file:///tmp/avatar.jpg');
   });
 
   it('throws AppError on upload failure', async () => {
-    mockClient.patch.mockRejectedValueOnce(makeAxiosError(500));
+    mockUploadAvatar.mockRejectedValueOnce(makeAxiosError(500));
     await expect(userRepository.updateAvatar('file:///tmp/avatar.jpg')).rejects.toBeInstanceOf(AppError);
   });
 });

--- a/services/repositories/userRepository.ts
+++ b/services/repositories/userRepository.ts
@@ -1,5 +1,6 @@
 import { authFetchClient as client } from '@/services/api/authFetch';
 import { handleApiError } from '@/services/api/errors';
+import { uploadAvatar } from '@/services/api/uploadAvatar';
 import { User } from '@/types';
 
 /**
@@ -59,15 +60,7 @@ export const userRepository = {
    */
   async updateAvatar(imageUri: string): Promise<User> {
     try {
-      const formData = new FormData();
-      formData.append('image', {
-        uri: imageUri,
-        type: 'image/jpeg',
-        name: 'avatar.jpg',
-      } as any);
-
-      const response = await client.patch<User>('/users', formData);
-      return response.data;
+      return await uploadAvatar(imageUri);
     } catch (error) {
       throw handleApiError(error);
     }


### PR DESCRIPTION
## Summary
- **Bug:** Profile image upload failed on mobile devices — never reached the API
- **Root cause:** RN 0.85 New Architecture no longer supports the `{ uri, type, name }` FormData convention, and its Blob implementation can't create from ArrayBuffer. Additionally, the API expects a JSON body with a base64 data URI, not multipart FormData.
- **Fix:** Read the image via `expo-file-system`'s `File` class, convert to base64 data URI, and send as a regular JSON PATCH through `authFetchClient`
- Also fixes deprecated `ImagePicker.MediaTypeOptions` usage

## Test plan
- [x] Upload profile image on iOS simulator — succeeds
- [ ] Upload profile image on Android device/emulator
- [ ] Upload profile image on web
- [ ] Remove profile image
- [ ] Verify image size limit (5MB) still enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)