### PR TITLE
ci: consolidate API URL and remove preview version sync

### DIFF
--- a/.eas/workflows/build-and-submit-preview.yml
+++ b/.eas/workflows/build-and-submit-preview.yml
@@ -1,4 +1,4 @@
-name: Build, Submit, and Sync Preview Version
+name: Build and Submit Preview
 
 on:
   push:
@@ -35,17 +35,3 @@ jobs:
       build_id: ${{ needs.build_android.outputs.build_id }}
       profile: preview
 
-  sync_version:
-    name: Sync preview version to API
-    needs: [submit_ios, submit_android]
-    env:
-      BUEBOKA_API_URL: ${{ env.BUEBOKA_API_URL }}
-      APP_ADMIN_API_KEY: ${{ env.APP_ADMIN_API_KEY }}
-      APP_VERSION: ${{ needs.build_ios.outputs.app_version }}
-    steps:
-      - name: Update preview app version in database
-        run: |
-          curl -f -X PUT "$BUEBOKA_API_URL/api/app/version" \
-            -H "Authorization: Bearer $APP_ADMIN_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d "{\"currentVersion\": \"$APP_VERSION\"}"

--- a/.eas/workflows/build-and-submit.yml
+++ b/.eas/workflows/build-and-submit.yml
@@ -39,13 +39,13 @@ jobs:
     name: Sync version to API
     needs: [submit_ios, submit_android]
     env:
-      BUEBOKA_API_URL: ${{ env.BUEBOKA_API_URL }}
+      EXPO_PUBLIC_API_URL: ${{ env.EXPO_PUBLIC_API_URL }}
       APP_ADMIN_API_KEY: ${{ env.APP_ADMIN_API_KEY }}
       APP_VERSION: ${{ needs.build_ios.outputs.app_version }}
     steps:
       - name: Update app version in database
         run: |
-          curl -f -X PUT "$BUEBOKA_API_URL/api/app/version" \
+          curl -f -X PUT "$EXPO_PUBLIC_API_URL/app/version" \
             -H "Authorization: Bearer $APP_ADMIN_API_KEY" \
             -H "Content-Type: application/json" \
             -d "{\"currentVersion\": \"$APP_VERSION\"}"


### PR DESCRIPTION
## Summary
- Remove version sync step from the preview workflow — preview builds should not update the production version in the database
- Consolidate production workflow to use `EXPO_PUBLIC_API_URL` instead of separate `BUEBOKA_API_URL`
- `BUEBOKA_API_URL` can be removed from EAS secrets

## Test plan
- [ ] Merge to `dev` — preview workflow should build and submit without version sync step
- [ ] Verify production workflow still syncs version correctly on merge to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)