### PR TITLE
fix(sightMarks): remove BowSpecification, fix ballistics, add set selector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,13 +91,16 @@ Domain discovery first — understand the ubiquitous language (see `docs/skills/
 
 ## Git workflow
 
-### Branching strategy
+### Branching model
 
-- **`dev`** is the default branch. All feature and fix branches are created from `dev` and merged back into `dev` via pull request.
-- **`main`** is the production branch. When a new version is ready to ship to users, `dev` is merged into `main` via pull request.
+`dev` is the default integration branch. `main` is production. Never push directly to either — all changes go through PRs. See `docs/skills/git-branching.md` for the full workflow.
+
+1. Branch from `dev` (e.g. `fix/short-description`, `feat/short-description`)
+2. Open a PR targeting `dev` — merge only after CI passes
+3. Promote `dev` → `main` via a separate PR — merge only after CI passes
+
 - Merging into `dev` triggers the **preview** EAS workflow — builds and submits to TestFlight (iOS) and Google Play internal track (Android) for beta testing.
 - Merging into `main` triggers the **production** EAS workflow — builds and submits to the App Store and Google Play production track.
-- Branch naming: `feat/<name>`, `fix/<name>`, `refactor/<name>`, `ci/<name>`, etc.
 
 ### Commit messages — Conventional Commits
 

--- a/components/sightMarks/calculatedMarksTable/CalculatedMarksTable.tsx
+++ b/components/sightMarks/calculatedMarksTable/CalculatedMarksTable.tsx
@@ -1,6 +1,7 @@
 import { Text, View } from 'react-native';
 import { MarksResult } from '@/types';
 import { styles } from './CalculatedMarksTableStyles';
+import { useTranslation } from '@/contexts';
 
 interface CalculatedMarksProps {
   marksData: MarksResult | null;
@@ -8,6 +9,7 @@ interface CalculatedMarksProps {
 }
 
 export default function CalculatedMarksTable({ marksData, showSpeed }: Readonly<CalculatedMarksProps>) {
+  const { t } = useTranslation();
   const renderMarksResultTable = () => {
     if (marksData) {
       return marksData.distances.map((distance, index) => (
@@ -41,7 +43,7 @@ export default function CalculatedMarksTable({ marksData, showSpeed }: Readonly<
             .map((angle) => {
               return (
                 <Text key={angle} style={styles.angle}>
-                  {angle}°
+                  {parseFloat(angle) === 0 ? t['calcMarks.flatMark'] : `${angle}°`}
                 </Text>
               );
             })}

--- a/components/sightMarks/screens/CalculateScreen.tsx
+++ b/components/sightMarks/screens/CalculateScreen.tsx
@@ -99,8 +99,8 @@ export default function CalculateScreen() {
           given_marks: givenMarks,
           given_distances: givenDistances,
           bow_category: bow.type,
-          interval_sight_real: bow.aimMeasure ?? 5,
-          interval_sight_measured: bow.aimMeasure ?? 5,
+          interval_sight_real: spec.intervalSightReal ?? Ballistics.interval_sight_real,
+          interval_sight_measured: spec.intervalSightMeasured ?? Ballistics.interval_sight_measured,
           arrow_diameter_mm: arrows?.diameter ?? 5,
           arrow_mass_gram: arrows?.weight ?? 21.2,
           length_eye_sight_cm: bow.eyeToSight ?? 0,
@@ -173,7 +173,7 @@ export default function CalculateScreen() {
           user?.id,
         );
       } else {
-        const { bow, arrows } = await ensureBowSpec();
+        const { bow, arrows, spec } = await ensureBowSpec();
         const lastIdx = givenMarks.length - 1;
         const body: AimDistanceMark = {
           ...Ballistics,
@@ -182,8 +182,8 @@ export default function CalculateScreen() {
           given_marks: givenMarks,
           given_distances: givenDistances,
           bow_category: bow.type,
-          interval_sight_real: bow.aimMeasure ?? 5,
-          interval_sight_measured: bow.aimMeasure ?? 5,
+          interval_sight_real: spec.intervalSightReal ?? Ballistics.interval_sight_real,
+          interval_sight_measured: spec.intervalSightMeasured ?? Ballistics.interval_sight_measured,
           arrow_diameter_mm: arrows?.diameter ?? 5,
           arrow_mass_gram: arrows?.weight ?? 21.2,
           length_eye_sight_cm: bow.eyeToSight ?? 0,

--- a/components/sightMarks/screens/CalculateScreen.tsx
+++ b/components/sightMarks/screens/CalculateScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Keyboard, Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { AimDistanceMark, Arrows, Bow, BowSpecification, MarkValue, SightMark } from '@/types';
+import { AimDistanceMark, Arrows, Bow, MarkValue, SightMark } from '@/types';
 import { useSharedValue, withTiming } from 'react-native-reanimated';
 import { Ballistics } from '@/utils';
 import * as Sentry from '@sentry/react-native';
@@ -53,17 +53,15 @@ export default function CalculateScreen() {
 
   // ─── Bow / arrow helpers ────────────────────────────────────────────────────
 
-  async function ensureBowSpec(): Promise<{ bow: Bow; arrows: Arrows | null; spec: BowSpecification }> {
+  const getEquipment = useCallback(async (): Promise<{ bow: Bow; arrows: Arrows | null }> => {
     const [bowsData, arrowsData] = await Promise.all([bowRepository.getAll(), arrowsRepository.getAll()]);
     const bows = Array.isArray(bowsData) ? bowsData : [];
     const arrows = Array.isArray(arrowsData) ? arrowsData : [];
     const bow = bows.find((b) => b.isFavorite) ?? bows[0];
     if (!bow) throw new Error(t['sightMarks.loadError']);
     const arrowSet = arrows.find((a) => a.isFavorite) ?? arrows[0] ?? null;
-    const spec = await sightMarksRepository.getBowSpecificationByBowId(bow.id);
-    if (!spec?.id) throw new Error(t['sightMarks.loadError']);
-    return { bow, arrows: arrowSet, spec };
-  }
+    return { bow, arrows: arrowSet };
+  }, [t]);
 
   // ─── Form open helpers ──────────────────────────────────────────────────────
 
@@ -88,7 +86,7 @@ export default function CalculateScreen() {
       try {
         setStatus('pending');
         setError(null);
-        const { bow, arrows, spec } = await ensureBowSpec();
+        const { bow, arrows } = await getEquipment();
         const givenMarks = [...(activeSightMark?.givenMarks ?? []), newMark.aim];
         const givenDistances = [...(activeSightMark?.givenDistances ?? []), newMark.distance];
 
@@ -99,8 +97,7 @@ export default function CalculateScreen() {
           given_marks: givenMarks,
           given_distances: givenDistances,
           bow_category: bow.type,
-          interval_sight_real: spec.intervalSightReal ?? Ballistics.interval_sight_real,
-          interval_sight_measured: spec.intervalSightMeasured ?? Ballistics.interval_sight_measured,
+          interval_sight_measured: bow.aimMeasure ?? Ballistics.interval_sight_measured,
           arrow_diameter_mm: arrows?.diameter ?? 5,
           arrow_mass_gram: arrows?.weight ?? 21.2,
           length_eye_sight_cm: bow.eyeToSight ?? 0,
@@ -124,7 +121,7 @@ export default function CalculateScreen() {
               type: 'sightMarks/createMark',
               payload: {
                 userId: user?.id,
-                bowSpecificationId: spec.id,
+                bowId: bow.id,
                 name: newMark.name,
                 givenMarks,
                 givenDistances,
@@ -134,7 +131,7 @@ export default function CalculateScreen() {
             () =>
               sightMarksRepository.create({
                 userId: user?.id,
-                bowSpecificationId: spec.id,
+                bowId: bow.id,
                 name: newMark.name,
                 givenMarks,
                 givenDistances,
@@ -153,7 +150,7 @@ export default function CalculateScreen() {
       }
       setStatus('idle');
     },
-    [ensureBowSpec, activeSightMark, loadData, user?.id, t],
+    [getEquipment, activeSightMark, loadData, user?.id, t],
   );
 
   // ─── Delete single mark from a set ─────────────────────────────────────────
@@ -173,7 +170,7 @@ export default function CalculateScreen() {
           user?.id,
         );
       } else {
-        const { bow, arrows, spec } = await ensureBowSpec();
+        const { bow, arrows } = await getEquipment();
         const lastIdx = givenMarks.length - 1;
         const body: AimDistanceMark = {
           ...Ballistics,
@@ -182,8 +179,7 @@ export default function CalculateScreen() {
           given_marks: givenMarks,
           given_distances: givenDistances,
           bow_category: bow.type,
-          interval_sight_real: spec.intervalSightReal ?? Ballistics.interval_sight_real,
-          interval_sight_measured: spec.intervalSightMeasured ?? Ballistics.interval_sight_measured,
+          interval_sight_measured: bow.aimMeasure ?? Ballistics.interval_sight_measured,
           arrow_diameter_mm: arrows?.diameter ?? 5,
           arrow_mass_gram: arrows?.weight ?? 21.2,
           length_eye_sight_cm: bow.eyeToSight ?? 0,

--- a/components/sightMarks/screens/MarksScreen.tsx
+++ b/components/sightMarks/screens/MarksScreen.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ScrollView, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Sentry from '@sentry/react-native';
-import { Button, Message } from '@/components/common';
+import { Button, Message, Select } from '@/components/common';
 import { CalculatedMarks, MarksResult, SightMark, SightMarkResult } from '@/types';
 import { CalculateMarksModal } from '@/components/sightMarks/calculateMarksModal/CalculateMarksModal';
 import CalculatedMarksTable from '@/components/sightMarks/calculatedMarksTable/CalculatedMarksTable';
@@ -29,38 +29,56 @@ export default function MarksScreen({ setScreen }: MarksScreenProps) {
   const insets = useSafeAreaInsets();
   const [showSpeed, setShowSpeed] = useState(false);
   // const [showGraph, setShowGraph] = useState(false);
+  const [sightMarks, setSightMarks] = useState<SightMark[]>([]);
   const [ballistics, setBallistics] = useState<CalculatedMarks | null>(null);
   const [calculatedMarks, setCalculatedMarks] = useState<MarksResult | null>(null);
   const [activeSightMark, setActiveSightMark] = useState<SightMark | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
+  const sightMarkOptions = useMemo(
+    () =>
+      sightMarks.map((sm) => ({
+        label: sm.name ?? sm.bow?.name ?? t['sightMarkCard.fallbackName'],
+        value: sm.id,
+      })),
+    [sightMarks, t],
+  );
+
+  const loadResultsForMark = useCallback(async (mark: SightMark) => {
+    setActiveSightMark(mark);
+    setBallistics((mark.ballisticsParameters as CalculatedMarks) ?? null);
+    try {
+      const results = await sightMarksRepository.getResults(mark.id);
+      const latest = results.sort((a, b) => new Date(b.createdAt ?? 0).getTime() - new Date(a.createdAt ?? 0).getTime())[0] ?? null;
+      setCalculatedMarks(latest ? mapResult(latest) : null);
+    } catch {
+      setCalculatedMarks(null);
+    }
+  }, []);
+
   const loadData = useCallback(async () => {
     setIsLoading(true);
     try {
       const marks = await sightMarksRepository.getAll();
       const sorted = marks.sort((a, b) => new Date(b.createdAt ?? 0).getTime() - new Date(a.createdAt ?? 0).getTime());
-      // Prefer the most recent collection that has 2+ calibration points; fall back to most recent
+      setSightMarks(sorted);
       const current = sorted.find((m) => (m.givenDistances?.length ?? 0) >= 2) ?? sorted[0] ?? null;
-      setActiveSightMark(current);
-      setBallistics((current?.ballisticsParameters as CalculatedMarks) ?? null);
 
       if (current) {
-        const results = await sightMarksRepository.getResults(current.id);
-        // Get newest result (most recent)
-        const latest = results.sort((a, b) => new Date(b.createdAt ?? 0).getTime() - new Date(a.createdAt ?? 0).getTime())[0] ?? null;
-        setCalculatedMarks(latest ? mapResult(latest) : null);
+        await loadResultsForMark(current);
       } else {
+        setActiveSightMark(null);
+        setBallistics(null);
         setCalculatedMarks(null);
       }
     } catch (error: any) {
-      // 404 is not an error - it just means no data exists yet
       if (error?.response?.status === 404) {
+        setSightMarks([]);
         setActiveSightMark(null);
         setBallistics(null);
         setCalculatedMarks(null);
       } else {
-        // Log actual errors to Sentry
         Sentry.captureException(error, {
           tags: { type: 'sight_marks_load_error' },
           extra: { message: error?.message, status: error?.response?.status },
@@ -69,7 +87,15 @@ export default function MarksScreen({ setScreen }: MarksScreenProps) {
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [loadResultsForMark]);
+
+  const handleSetChange = useCallback(
+    (sightMarkId: string) => {
+      const selected = sightMarks.find((sm) => sm.id === sightMarkId);
+      if (selected) loadResultsForMark(selected);
+    },
+    [sightMarks, loadResultsForMark],
+  );
 
   useEffect(() => {
     loadData();
@@ -166,7 +192,20 @@ export default function MarksScreen({ setScreen }: MarksScreenProps) {
       {/* {showGraph ? (
         <ChartScreen calculatedMarks={calculatedMarks} marks={ballistics} setModalVisible={setModalVisible} />
       ) : ( */}
-      <ScrollView style={styles.scrollView}>{renderContent()}</ScrollView>
+      <ScrollView style={styles.scrollView}>
+        {sightMarkOptions.length > 1 && (
+          <View style={styles.selectorContainer}>
+            <Select
+              label={t['sightMarks.selectSet']}
+              options={sightMarkOptions}
+              selectedValue={activeSightMark?.id}
+              onValueChange={handleSetChange}
+              zIndex={2000}
+            />
+          </View>
+        )}
+        {renderContent()}
+      </ScrollView>
       {/* )} */}
 
       {calculatedMarks && (

--- a/components/sightMarks/screens/MarksScreen.tsx
+++ b/components/sightMarks/screens/MarksScreen.tsx
@@ -182,7 +182,7 @@ export default function MarksScreen({ setScreen }: MarksScreenProps) {
   }
 
   const outlineWhite = {
-    buttonStyle: { borderColor: colors.white },
+    buttonStyle: { borderColor: colors.white, flex: 1 } as const,
     textStyle: { color: colors.white },
   };
 
@@ -213,18 +213,18 @@ export default function MarksScreen({ setScreen }: MarksScreenProps) {
           <View style={styles.buttons}>
             <Button
               type="outline"
-              buttonStyle={{ flex: 1 }}
+              size="small"
               iconPosition="left"
-              icon={<FontAwesomeIcon icon={faWind} size={20} color={colors.white} />}
+              icon={<FontAwesomeIcon icon={faWind} size={16} color={colors.white} />}
               label={t['sightMarks.showSpeed']}
               onPress={() => setShowSpeed(!showSpeed)}
               {...outlineWhite}
             />
             <Button
               type="outline"
-              buttonStyle={{ flex: 1 }}
+              size="small"
               iconPosition="left"
-              icon={<FontAwesomeIcon icon={faRotateRight} color={colors.white} />}
+              icon={<FontAwesomeIcon icon={faRotateRight} size={16} color={colors.white} />}
               label={t['sightMarks.recalculate']}
               onPress={handleRemoveMarks}
               {...outlineWhite}

--- a/components/sightMarks/screens/MarksScreen.tsx
+++ b/components/sightMarks/screens/MarksScreen.tsx
@@ -210,19 +210,19 @@ export default function MarksScreen({ setScreen }: MarksScreenProps) {
 
       {calculatedMarks && (
         <View style={[styles.actionBar, { paddingBottom: insets.bottom + 80 }]}>
-          {
+          <View style={styles.buttons}>
             <Button
               type="outline"
+              buttonStyle={{ flex: 1 }}
               iconPosition="left"
               icon={<FontAwesomeIcon icon={faWind} size={20} color={colors.white} />}
               label={t['sightMarks.showSpeed']}
               onPress={() => setShowSpeed(!showSpeed)}
               {...outlineWhite}
             />
-          }
-          <View style={styles.buttons}>
             <Button
               type="outline"
+              buttonStyle={{ flex: 1 }}
               iconPosition="left"
               icon={<FontAwesomeIcon icon={faRotateRight} color={colors.white} />}
               label={t['sightMarks.recalculate']}

--- a/components/sightMarks/screens/MarksScreenStyles.ts
+++ b/components/sightMarks/screens/MarksScreenStyles.ts
@@ -8,6 +8,11 @@ export const styles = StyleSheet.create({
     flex: 1,
     minHeight: '50%',
   },
+  selectorContainer: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    zIndex: 2000,
+  },
   emptyState: {
     marginTop: 'auto',
     padding: 16,

--- a/components/sightMarks/screens/MarksScreenStyles.ts
+++ b/components/sightMarks/screens/MarksScreenStyles.ts
@@ -27,5 +27,6 @@ export const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
+    gap: 8,
   },
 });

--- a/components/sightMarks/sightMarkSetCard/SightMarkSetCard.tsx
+++ b/components/sightMarks/sightMarkSetCard/SightMarkSetCard.tsx
@@ -24,7 +24,7 @@ export default function SightMarkSetCard({ sightMark, onAddMark, onDeleteMark, o
 
   const ballistics = sightMark.ballisticsParameters as CalculatedMarks | null;
   const markCount = sightMark.givenMarks?.length ?? 0;
-  const displayName = sightMark.name ?? sightMark.bowSpec?.bow?.name ?? t['sightMarkCard.fallbackName'];
+  const displayName = sightMark.name ?? sightMark.bow?.name ?? t['sightMarkCard.fallbackName'];
 
   return (
     <View style={styles.card}>

--- a/docs/skills/git-branching.md
+++ b/docs/skills/git-branching.md
@@ -1,0 +1,71 @@
+# Skill: Git Branching Workflow
+
+## Purpose
+
+Protect `main` and `dev` from direct pushes. All changes flow through feature/fix branches
+and pull requests, ensuring CI passes before code reaches the next environment.
+
+---
+
+## Branch Hierarchy
+
+```
+main          ← production; receives merges only from dev via PR
+  └── dev     ← integration branch; receives merges from feature/fix branches via PR
+        ├── feat/description
+        ├── fix/description
+        └── chore/description
+```
+
+---
+
+## Rules
+
+### 1. Never Push Directly to `main` or `dev`
+
+All work happens on a branch created **from `dev`**. No commits should be pushed
+directly to `main` or `dev` — always go through a pull request.
+
+### 2. Branch From `dev`
+
+Every new branch must be based on the latest `dev`:
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b fix/short-description
+```
+
+Use the Conventional Commits type as the branch prefix (`feat/`, `fix/`, `refactor/`,
+`chore/`, `ci/`, `test/`, `docs/`).
+
+### 3. Pull Request to `dev` First
+
+When work is ready, push the branch and open a PR targeting `dev`:
+
+```bash
+git push -u origin fix/short-description
+gh pr create --base dev --title "fix: short description" --body "..."
+```
+
+The PR must pass CI before merging.
+
+### 4. Promote `dev` to `main` Only After CI Succeeds
+
+Once changes are merged into `dev` and the pipeline succeeds, open a PR from `dev`
+to `main`:
+
+```bash
+gh pr create --base main --head dev --title "release: merge dev into main" --body "..."
+```
+
+Only merge this PR when all checks pass.
+
+### 5. Summary
+
+```
+feature/fix branch  →  PR to dev  →  CI passes  →  merge
+dev                 →  PR to main →  CI passes  →  merge
+```
+
+No shortcuts. No force-pushes to protected branches.

--- a/docs/skills/tdd-ddd.md
+++ b/docs/skills/tdd-ddd.md
@@ -162,7 +162,7 @@ Write a test for every invariant before adding the validation code.
 7. TEST (RED) – Write a failing component/acceptance test
 8. IMPLEMENT  – Wire up the screen/component
 9. REFACTOR   – Clean up all three layers; all tests must stay green
-10. COMMIT    – Follow commit message conventions in AGENTS.md
+10. COMMIT    – Follow commit message conventions in CLAUDE.md
 ```
 
 Never move to the next step until the current tests pass.

--- a/lib/i18n/translations/en.ts
+++ b/lib/i18n/translations/en.ts
@@ -472,6 +472,7 @@ export const en: TranslationKeys = {
   'sightMarks.noDataDescription': 'Add your marks to calculate sight marks.',
   'sightMarks.showSpeed': 'Show speeds',
   'sightMarks.recalculate': 'Recalculate',
+  'sightMarks.selectSet': 'Select sighting',
 
   'calcMarks.fromDistance': 'From distance',
   'calcMarks.toDistance': 'To distance',

--- a/lib/i18n/translations/en.ts
+++ b/lib/i18n/translations/en.ts
@@ -481,6 +481,7 @@ export const en: TranslationKeys = {
   'calcMarks.angle': 'Angle',
   'calcMarks.ballisticsMissing': 'Ballistics data missing. Add a sight mark first.',
   'calcMarks.calculate': 'Calculate',
+  'calcMarks.flatMark': 'Flat',
 
   'marksForm.nameLabel': 'Sighting name (optional)',
   'marksForm.namePlaceholder': 'e.g. Outdoor 2025',

--- a/lib/i18n/translations/no.ts
+++ b/lib/i18n/translations/no.ts
@@ -481,6 +481,7 @@ export const no: TranslationKeys = {
   'calcMarks.angle': 'Vinkel',
   'calcMarks.ballisticsMissing': 'Ballistikkdata mangler. Legg inn et siktemerke først.',
   'calcMarks.calculate': 'Beregn',
+  'calcMarks.flatMark': 'Flatmark',
 
   'marksForm.nameLabel': 'Navn på innskyting (valgfritt)',
   'marksForm.namePlaceholder': 'F.eks. Utendørs 2025',

--- a/lib/i18n/translations/no.ts
+++ b/lib/i18n/translations/no.ts
@@ -472,6 +472,7 @@ export const no: TranslationKeys = {
   'sightMarks.noDataDescription': 'Legg inn dine merker for å beregne siktemerker.',
   'sightMarks.showSpeed': 'Vis hastigheter',
   'sightMarks.recalculate': 'Beregn på nytt',
+  'sightMarks.selectSet': 'Velg innskyting',
 
   'calcMarks.fromDistance': 'Fra avstand',
   'calcMarks.toDistance': 'Til avstand',

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -521,6 +521,7 @@ export interface TranslationKeys {
   'calcMarks.angle': string;
   'calcMarks.ballisticsMissing': string;
   'calcMarks.calculate': string;
+  'calcMarks.flatMark': string;
 
   // Marks form (sliding sheet)
   'marksForm.nameLabel': string;

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -511,6 +511,7 @@ export interface TranslationKeys {
   'sightMarks.noDataDescription': string;
   'sightMarks.showSpeed': string;
   'sightMarks.recalculate': string;
+  'sightMarks.selectSet': string;
 
   // Calculate marks modal
   'calcMarks.fromDistance': string;

--- a/services/offline/handlers.ts
+++ b/services/offline/handlers.ts
@@ -35,8 +35,6 @@ export function registerOfflineHandlers() {
   syncManager.registerHandler('sightMarks/deleteMark', handleDeleteSightMark);
   syncManager.registerHandler('sightMarks/createResult', handleCreateSightMarkResult);
   syncManager.registerHandler('sightMarks/deleteResult', handleDeleteSightMarkResult);
-  syncManager.registerHandler('sightMarks/createSpec', handleCreateBowSpecification);
-
   // User handlers
   syncManager.registerHandler('user/update', handleUpdateUser);
 }
@@ -57,7 +55,7 @@ const handleDeleteBow: OperationHandler = async (op) => {
 
 const handleToggleFavoriteBow: OperationHandler = async (op) => {
   const { id, isFavorite } = op.payload;
-  await bowRepository.toggleFavorite(id, isFavorite);
+  await bowRepository.update(id, { isFavorite });
 };
 
 // Arrows handlers
@@ -129,10 +127,6 @@ const handleCreateSightMarkResult: OperationHandler = async (op) => {
 
 const handleDeleteSightMarkResult: OperationHandler = async (op) => {
   await sightMarksRepository.deleteResult(op.payload.id);
-};
-
-const handleCreateBowSpecification: OperationHandler = async (op) => {
-  await sightMarksRepository.createSpecification(op.payload);
 };
 
 // User handlers

--- a/services/repositories/__tests__/sightMarksRepository.test.ts
+++ b/services/repositories/__tests__/sightMarksRepository.test.ts
@@ -1,7 +1,7 @@
 import { AxiosError, AxiosHeaders } from 'axios';
 import { sightMarksRepository } from '@/services/repositories';
 import { authFetchClient } from '@/services/api/authFetch';
-import { BowSpecification, SightMark, SightMarkResult } from '@/types';
+import { SightMark, SightMarkResult } from '@/types';
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -40,22 +40,11 @@ function makeAxiosError(status: number): AxiosError {
 const fakeSightMark: SightMark = {
   id: 'sm-1',
   userId: 'user-1',
-  bowSpecificationId: 'spec-1',
+  bowId: 'bow-1',
   name: 'Innendørs 18m',
   givenMarks: [120, 115, 112],
   givenDistances: [18, 25, 30],
   ballisticsParameters: null,
-  createdAt: '2024-01-01T00:00:00.000Z',
-  updatedAt: '2024-01-01T00:00:00.000Z',
-};
-
-const fakeBowSpec: BowSpecification = {
-  id: 'spec-1',
-  userId: 'user-1',
-  bowId: 'bow-1',
-  intervalSightReal: 4.2,
-  intervalSightMeasured: 4.0,
-  placement: null,
   createdAt: '2024-01-01T00:00:00.000Z',
   updatedAt: '2024-01-01T00:00:00.000Z',
 };
@@ -147,45 +136,6 @@ describe('sightMarksRepository.delete', () => {
     mockClient.delete.mockResolvedValueOnce({ data: undefined });
     await sightMarksRepository.delete('sm-1');
     expect(mockClient.delete).toHaveBeenCalledWith('/sight-marks/sm-1');
-  });
-});
-
-// ── getBowSpecificationByBowId ────────────────────────────────────────────────
-
-describe('sightMarksRepository.getBowSpecificationByBowId', () => {
-  it('unwraps the { bowSpecification } envelope and returns the spec', async () => {
-    mockClient.get.mockResolvedValueOnce({ data: { bowSpecification: fakeBowSpec } });
-    const result = await sightMarksRepository.getBowSpecificationByBowId('bow-1');
-    expect(result).toEqual(fakeBowSpec);
-    expect(mockClient.get).toHaveBeenCalledWith('/bow-specifications/by-bow/bow-1');
-  });
-
-  it('returns a flat BowSpecification when there is no wrapper', async () => {
-    mockClient.get.mockResolvedValueOnce({ data: fakeBowSpec });
-    const result = await sightMarksRepository.getBowSpecificationByBowId('bow-1');
-    expect(result.id).toBe('spec-1');
-  });
-
-  it('throws when the spec is missing the id field', async () => {
-    mockClient.get.mockResolvedValueOnce({ data: { bowSpecification: { bowId: 'bow-1' } } });
-    await expect(sightMarksRepository.getBowSpecificationByBowId('bow-1')).rejects.toThrow();
-  });
-});
-
-// ── createSpecification ───────────────────────────────────────────────────────
-
-describe('sightMarksRepository.createSpecification', () => {
-  it('sends POST to /bow-specifications and returns the spec', async () => {
-    mockClient.post.mockResolvedValueOnce({ data: fakeBowSpec });
-    const result = await sightMarksRepository.createSpecification({ bowId: 'bow-1' });
-    expect(result).toEqual(fakeBowSpec);
-    expect(mockClient.post).toHaveBeenCalledWith('/bow-specifications', { bowId: 'bow-1' });
-  });
-
-  it('re-throws errors without wrapping in AppError', async () => {
-    const rawError = makeAxiosError(400);
-    mockClient.post.mockRejectedValueOnce(rawError);
-    await expect(sightMarksRepository.createSpecification({ bowId: 'bow-1' })).rejects.toBe(rawError);
   });
 });
 

--- a/services/repositories/sightMarksRepository.ts
+++ b/services/repositories/sightMarksRepository.ts
@@ -1,6 +1,5 @@
 import { authFetchClient as client } from '@/services/api/authFetch';
-import { AimDistanceMark, BowSpecification, CalculatedMarks, MarksResult, SightMark, SightMarkCalc, SightMarkResult } from '@/types';
-import * as Sentry from '@sentry/react-native';
+import { AimDistanceMark, CalculatedMarks, MarksResult, SightMark, SightMarkCalc, SightMarkResult } from '@/types';
 
 export const sightMarksRepository = {
   async getAll(): Promise<SightMark[]> {
@@ -25,42 +24,6 @@ export const sightMarksRepository = {
   },
   async delete(id: string): Promise<void> {
     await client.delete(`/sight-marks/${id}`);
-  },
-
-  async getBowSpecificationByBowId(bowId: string): Promise<BowSpecification> {
-    const response = await client.get<{ bowSpecification: BowSpecification } | BowSpecification>(`/bow-specifications/by-bow/${bowId}`);
-
-    // Handle wrapped response { bowSpecification: {...} } or direct response
-    const spec = (response.data as any)?.bowSpecification || response.data;
-
-    if (!spec?.id) {
-      Sentry.captureMessage('Bow specification missing id field', {
-        level: 'error',
-        extra: { responseData: response.data, bowId },
-      });
-      throw new Error('Bow specification response is missing id field');
-    }
-
-    return spec;
-  },
-
-  async createSpecification(data: Partial<BowSpecification>): Promise<BowSpecification> {
-    try {
-      const response = await client.post<BowSpecification>('/bow-specifications', data);
-      return response.data;
-    } catch (error: any) {
-      // Log the error to Sentry with context
-      Sentry.captureException(error, {
-        tags: { type: 'bow_specification_create_error' },
-        extra: {
-          status: error.response?.status,
-          message: error.response?.data?.message || error.message,
-          bowId: data.bowId,
-        },
-      });
-
-      throw error;
-    }
   },
 
   async getResults(sightMarkId: string): Promise<SightMarkResult[]> {

--- a/types/SightMarks.ts
+++ b/types/SightMarks.ts
@@ -2,38 +2,17 @@
  * SightMarks feature types
  */
 
-export enum Placement {
-  BAK_LINJEN = 'BAK_LINJEN',
-  OVER_LINJEN = 'OVER_LINJEN',
-  ANNET = 'ANNET',
-}
-
-export interface BowSpecification {
-  id: string;
-  userId: string;
-  bowId: string;
-  intervalSightReal: number | null;
-  intervalSightMeasured: number | null;
-  placement: Placement | null;
-  createdAt: string;
-  updatedAt: string;
-}
-
 export interface SightMark {
   id: string;
   userId: string;
-  bowSpecificationId: string;
+  bowId: string;
   name: string | null;
   givenMarks: number[];
   givenDistances: number[];
   ballisticsParameters: any;
   createdAt: string;
   updatedAt: string;
-  /** Populated by the API when the relation is included */
-  bowSpec?: {
-    id: string;
-    bow?: { id: string; name: string };
-  };
+  bow?: { id: string; name: string; type?: string };
 }
 
 export interface SightMarkResult {

--- a/types/index.ts
+++ b/types/index.ts
@@ -11,7 +11,6 @@ export type { PracticeFilter } from './Practice';
 export { Environment, WeatherCondition, PracticeCategory } from './Practice';
 export type { Competition, CompetitionRound } from './Competition';
 export type {
-  BowSpecification,
   SightMark,
   SightMarkResult,
   AimDistanceMark,


### PR DESCRIPTION
## Summary
- **Remove BowSpecification**: the API no longer has this model. SightMark now links directly to Bow via `bowId`. All related types, repository methods, offline handlers, and tests are removed.
- **Fix ballistics payload**: only override `interval_sight_measured` with `bow.aimMeasure`; let `interval_sight_real` keep the default (5.0) so the scaling ratio is meaningful.
- **Add set selector on marks screen**: users with multiple sighting sets can now choose which one to use for calculating sight marks, matching the web version.
- **UI polish**: speed and recalculate buttons share one row; 0° column header shows "Flatmark"/"Flat" instead of "0°".
- **Docs**: add git branching workflow skill, fix stale `AGENTS.md` reference in tdd-ddd.md.
- **Fix offline handler**: `handleToggleFavoriteBow` called non-existent `toggleFavorite` — now uses `bowRepository.update`.

## Test plan
- [x] All 442 tests pass
- [x] No new TypeScript errors in changed files
- [x] No new ESLint errors
- [ ] Verify sight mark set selector appears when multiple sets exist
- [ ] Verify ballistics calculation produces different results when `aimMeasure` is changed
- [ ] Verify creating a new sight mark sends `bowId` instead of `bowSpecificationId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)