### PR TITLE
fix: correct felt target sizes to 20, 40, and 60 cm

### DIFF
--- a/lib/i18n/translations/en.ts
+++ b/lib/i18n/translations/en.ts
@@ -198,7 +198,8 @@ export const en: TranslationKeys = {
   'target.size80cm': '80 cm',
   'target.size122cm': '122 cm',
   'target.figure3D': '3D figure',
-  'target.field24cm': 'Field 24 cm',
+  'target.field20cm': 'Field 20 cm',
+  'target.field40cm': 'Field 40 cm',
   'target.field60cm': 'Field 60 cm',
   'target.other': 'Other',
 

--- a/lib/i18n/translations/no.ts
+++ b/lib/i18n/translations/no.ts
@@ -198,7 +198,8 @@ export const no: TranslationKeys = {
   'target.size80cm': '80 cm',
   'target.size122cm': '122 cm',
   'target.figure3D': '3D figur',
-  'target.field24cm': 'Felt 24 cm',
+  'target.field20cm': 'Felt 20 cm',
+  'target.field40cm': 'Felt 40 cm',
   'target.field60cm': 'Felt 60 cm',
   'target.other': 'Annet',
 

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -221,7 +221,8 @@ export interface TranslationKeys {
   'target.size80cm': string;
   'target.size122cm': string;
   'target.figure3D': string;
-  'target.field24cm': string;
+  'target.field20cm': string;
+  'target.field40cm': string;
   'target.field60cm': string;
   'target.other': string;
 

--- a/utils/Constants.ts
+++ b/utils/Constants.ts
@@ -12,7 +12,8 @@ export const TARGET_TYPES: { value: string; key: keyof TranslationKeys; label: s
   { value: '80cm', key: 'target.size80cm', label: '80 cm' },
   { value: '122cm', key: 'target.size122cm', label: '122 cm' },
   { value: '3d', key: 'target.figure3D', label: '3D figur' },
-  { value: '24cm_felt', key: 'target.field24cm', label: 'Felt 24 cm' },
+  { value: '20cm_felt', key: 'target.field20cm', label: 'Felt 20 cm' },
+  { value: '40cm_felt', key: 'target.field40cm', label: 'Felt 40 cm' },
   { value: '60cm_felt', key: 'target.field60cm', label: 'Felt 60 cm' },
   { value: 'other', key: 'target.other', label: 'Annet' },
 ];


### PR DESCRIPTION
## Summary
- Replaced the incorrect 24 cm felt target with 20 cm
- Added the missing 40 cm felt target size
- Felt targets are now 20 cm, 40 cm, and 60 cm as intended

## Test plan
- [x] All existing tests pass (36 suites, 439 tests)
- [ ] Verify felt target options appear correctly in practice and competition forms

🤖 Generated with [Claude Code](https://claude.ai/code)