### PR TITLE
feat(select): add creatable option and fix profile update endpoint

### DIFF
--- a/components/common/Select/Select.tsx
+++ b/components/common/Select/Select.tsx
@@ -18,6 +18,7 @@ import { colors } from '@/styles/colors';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons/faChevronDown';
 import { faCheck } from '@fortawesome/free-solid-svg-icons/faCheck';
+import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { useTranslation } from '@/contexts';
 
 type Option = {
@@ -37,6 +38,9 @@ type Props = {
   zIndex?: number;
   searchable?: boolean;
   placeholder?: string;
+  creatable?: boolean;
+  createLabel?: string;
+  onCreateOption?: (value: string) => void;
 };
 
 export const Select: React.FC<Props> = ({
@@ -51,6 +55,9 @@ export const Select: React.FC<Props> = ({
   zIndex = 1000,
   searchable = false,
   placeholder,
+  creatable = false,
+  createLabel,
+  onCreateOption,
 }) => {
   const { t } = useTranslation();
   const resolvedPlaceholder = placeholder ?? t['common.chooseOption'];
@@ -103,6 +110,28 @@ export const Select: React.FC<Props> = ({
     }).start();
   };
 
+  const handleCreate = () => {
+    const trimmed = searchQuery.trim();
+    if (!trimmed) return;
+    if (onCreateOption) {
+      onCreateOption(trimmed);
+    } else {
+      onValueChange(trimmed);
+    }
+    setOpen(false);
+    setSearchQuery('');
+    Animated.timing(rotateAnim, {
+      toValue: 0,
+      duration: 180,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  const showCreateOption =
+    creatable &&
+    searchQuery.trim().length > 0 &&
+    !options.some((opt) => opt.label.toLowerCase() === searchQuery.trim().toLowerCase());
+
   const rotate = rotateAnim.interpolate({
     inputRange: [0, 1],
     outputRange: ['0deg', '180deg'],
@@ -123,6 +152,8 @@ export const Select: React.FC<Props> = ({
     </Pressable>
   );
 
+  const resolvedCreateLabel = createLabel ?? t['common.create'];
+
   const renderDropdownContent = () => (
     <ScrollView
       style={styles.optionsList}
@@ -130,13 +161,21 @@ export const Select: React.FC<Props> = ({
       showsVerticalScrollIndicator={true}
       keyboardShouldPersistTaps="handled"
       bounces={Platform.OS === 'ios'}>
-      {filteredOptions.length > 0 ? (
-        filteredOptions.map(renderOption)
-      ) : (
-        <View style={styles.option}>
-          <Text style={[styles.optionText, { color: colors.dimmed }]}>{t['common.noResults']}</Text>
-        </View>
+      {showCreateOption && (
+        <Pressable style={styles.createOption} onPress={handleCreate} android_ripple={{ color: colors.tertiary }}>
+          <FontAwesomeIcon icon={faPlus} size={14} color={colors.secondary} />
+          <Text style={styles.createOptionText}>
+            {resolvedCreateLabel} "{searchQuery.trim()}"
+          </Text>
+        </Pressable>
       )}
+      {filteredOptions.length > 0
+        ? filteredOptions.map(renderOption)
+        : !showCreateOption && (
+            <View style={styles.option}>
+              <Text style={[styles.optionText, { color: colors.dimmed }]}>{t['common.noResults']}</Text>
+            </View>
+          )}
     </ScrollView>
   );
 

--- a/components/common/Select/Select.tsx
+++ b/components/common/Select/Select.tsx
@@ -137,7 +137,8 @@ export const Select: React.FC<Props> = ({
     outputRange: ['0deg', '180deg'],
   });
 
-  const selectedLabel = options.find((opt) => opt.value === selectedValue)?.label || resolvedPlaceholder;
+  const matchedLabel = options.find((opt) => opt.value === selectedValue)?.label;
+  const selectedLabel = matchedLabel || (creatable && selectedValue ? selectedValue : resolvedPlaceholder);
 
   const renderOption = (item: Option, index: number) => (
     <Pressable

--- a/components/common/Select/SelectStyles.ts
+++ b/components/common/Select/SelectStyles.ts
@@ -141,6 +141,22 @@ const styles = StyleSheet.create({
     flex: 1,
     marginRight: 8,
   },
+  createOption: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 16,
+    backgroundColor: colors.bgGray50,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.dimmed,
+    minHeight: 50,
+    gap: 10,
+  },
+  createOptionText: {
+    fontSize: 14,
+    color: colors.secondary,
+    fontWeight: '500',
+    flex: 1,
+  },
 });
 
 export default styles;

--- a/components/home/profileForm/ProfileForm.tsx
+++ b/components/home/profileForm/ProfileForm.tsx
@@ -66,6 +66,7 @@ export default function ProfileForm({ modalVisible, setModalVisible, user, onSav
             selectedValue={club}
             onValueChange={setClub}
             searchable={true}
+            creatable={true}
             placeholder={t['profileForm.clubPlaceholder']}
           />
           <Input

--- a/lib/i18n/translations/en.ts
+++ b/lib/i18n/translations/en.ts
@@ -512,6 +512,7 @@ export const en: TranslationKeys = {
   'common.favourite': 'Favourite',
   'common.noResults': 'No results',
   'common.chooseOption': 'Choose an option',
+  'common.create': 'Create',
 
   // Settings screen
   'settings.title': 'Settings',

--- a/lib/i18n/translations/no.ts
+++ b/lib/i18n/translations/no.ts
@@ -512,6 +512,7 @@ export const no: TranslationKeys = {
   'common.favourite': 'Favoritt',
   'common.noResults': 'Ingen treff',
   'common.chooseOption': 'Velg et alternativ',
+  'common.create': 'Opprett',
 
   // Settings screen
   'settings.title': 'Innstillinger',

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -556,6 +556,7 @@ export interface TranslationKeys {
   'common.favourite': string;
   'common.noResults': string;
   'common.chooseOption': string;
+  'common.create': string;
 
   // Settings screen
   'settings.title': string;

--- a/services/repositories/__tests__/userRepository.test.ts
+++ b/services/repositories/__tests__/userRepository.test.ts
@@ -97,20 +97,20 @@ describe('userRepository.getCurrentUser', () => {
 // ── updateProfile ─────────────────────────────────────────────────────────────
 
 describe('userRepository.updateProfile', () => {
-  it('sends a PATCH to /profile and returns the updated user', async () => {
+  it('sends a PATCH to /users and returns the updated user', async () => {
     const updated = { ...fakeUser, name: 'Kari Nordmann' };
     mockClient.patch.mockResolvedValueOnce({ data: updated });
 
     const result = await userRepository.updateProfile({ name: 'Kari Nordmann' });
 
     expect(result.name).toBe('Kari Nordmann');
-    expect(mockClient.patch).toHaveBeenCalledWith('/profile', { name: 'Kari Nordmann' });
+    expect(mockClient.patch).toHaveBeenCalledWith('/users', { name: 'Kari Nordmann' });
   });
 
   it('can send club and skytternr together', async () => {
     mockClient.patch.mockResolvedValueOnce({ data: fakeUser });
     await userRepository.updateProfile({ name: 'Ola', club: 'Bergen BK', skytternr: '99' });
-    expect(mockClient.patch).toHaveBeenCalledWith('/profile', { name: 'Ola', club: 'Bergen BK', skytternr: '99' });
+    expect(mockClient.patch).toHaveBeenCalledWith('/users', { name: 'Ola', club: 'Bergen BK', skytternr: '99' });
   });
 
   it('throws AppError with BAD_REQUEST on 400', async () => {

--- a/services/repositories/userRepository.ts
+++ b/services/repositories/userRepository.ts
@@ -43,11 +43,11 @@ export const userRepository = {
 
   /**
    * Update current user profile
-   * PATCH /api/profile
+   * PATCH /api/users
    */
   async updateProfile(data: UpdateUserData): Promise<User> {
     try {
-      const response = await client.patch<User>('/profile', data);
+      const response = await client.patch<User>('/users', data);
       return response.data;
     } catch (error) {
       throw handleApiError(error);


### PR DESCRIPTION
## Summary
- Extended the `Select` component with `creatable`, `createLabel`, and `onCreateOption` props — when enabled, users can type a custom value that doesn't exist in the options list
- Enabled creatable on the club selector in ProfileForm so users outside Norway can add their own club
- Fixed `updateProfile` to use the correct `/users` endpoint instead of `/profile` (which is GET-only)

## Test plan
- [x] All existing tests pass (36 suites, 439 tests)
- [x] User repository tests updated to verify `/users` endpoint
- [ ] Verify club selector shows "Create" option when typing a non-Norwegian club
- [ ] Verify custom club name is saved and displayed correctly after save
- [ ] Verify existing Norwegian club selection still works as before

🤖 Generated with [Claude Code](https://claude.ai/code)