### PR TITLE
fix: refresh stats and count all arrows in achievements

### DIFF
--- a/app/(tabs)/home/index.tsx
+++ b/app/(tabs)/home/index.tsx
@@ -95,6 +95,7 @@ export default function HomeScreen() {
 
   const handlePracticesSaved = () => {
     setPracticesRefreshKey((k) => k + 1);
+    loadData();
   };
 
   async function handleAvatarUpload(uri: string) {

--- a/services/achievements/__tests__/checker.test.ts
+++ b/services/achievements/__tests__/checker.test.ts
@@ -66,12 +66,12 @@ function makeBow(type: BowType) {
   };
 }
 
-function makeEnd(arrows: number, scores: number[] = []): Practice['ends'][number] {
+function makeEnd(arrows: number, scores: number[] = [], arrowsWithoutScore: number | null = null): Practice['ends'][number] {
   return {
     id: 'e1',
     practiceId: 'p1',
     arrows,
-    arrowsWithoutScore: null,
+    arrowsWithoutScore,
     scores,
     roundScore: scores.length > 0 ? scores.reduce((a, b) => a + b, 0) : null,
     distanceMeters: null,
@@ -106,6 +106,20 @@ describe('calculateUserStats – edge cases', () => {
     expect(stats.practicesByCategory['UNKNOWN_CAT']).toBeUndefined();
   });
 
+  it('includes arrowsWithoutScore in totalArrows', () => {
+    const practice = makePractice({ ends: [makeEnd(6, [], 4)] });
+    const stats = calculateUserStats([practice]);
+    expect(stats.totalArrows).toBe(10);
+  });
+
+  it('sums both scored and unscored arrows across multiple ends', () => {
+    const practice = makePractice({
+      ends: [makeEnd(3, [], 2), makeEnd(5, [], 3)],
+    });
+    const stats = calculateUserStats([practice]);
+    expect(stats.totalArrows).toBe(13);
+  });
+
   it('does not track bow type when bow is undefined', () => {
     const practice = makePractice({ bow: undefined });
     const stats = calculateUserStats([practice]);
@@ -119,6 +133,12 @@ describe('calculateUserStats – edge cases', () => {
     ];
     const stats = calculateUserStats(practices);
     expect(stats.arrowsByBowType['RECURVE']).toBe(50);
+  });
+
+  it('includes arrowsWithoutScore in arrowsByBowType', () => {
+    const practice = makePractice({ bow: makeBow(BowType.RECURVE), ends: [makeEnd(6, [], 4)] });
+    const stats = calculateUserStats([practice]);
+    expect(stats.arrowsByBowType['RECURVE']).toBe(10);
   });
 });
 
@@ -362,6 +382,34 @@ describe('checkAllAchievements – BOW_TYPE_COUNT increments', () => {
     const result = checkAllAchievements(practices, [], true);
     const entry = result.find((r) => r.achievement.id === 'master-of-all-bows')!;
     expect(entry.isUnlocked).toBe(false);
+  });
+});
+
+// ── Unscored arrows in achievements ─────────────────────────────────────────
+
+describe('checkAllAchievements – unscored arrows count towards totals', () => {
+  it('unlocks arrows-1000 when scored + unscored arrows reach threshold', () => {
+    const practice = makePractice({ ends: [makeEnd(600, [], 400)] });
+    const result = checkAllAchievements([practice], [], true);
+    const entry = result.find((r) => r.achievement.id === 'arrows-1000')!;
+    expect(entry.isUnlocked).toBe(true);
+    expect(entry.current).toBe(1000);
+  });
+
+  it('unlocks big-session when scored + unscored arrows reach 200 in one session', () => {
+    const practice = makePractice({ ends: [makeEnd(120, [], 80)] });
+    const result = checkAllAchievements([practice], [], true);
+    const entry = result.find((r) => r.achievement.id === 'big-session')!;
+    expect(entry.isUnlocked).toBe(true);
+    expect(entry.current).toBe(200);
+  });
+
+  it('unlocks recurve-dedicated when scored + unscored recurve arrows reach 10,000', () => {
+    const practice = makePractice({ bow: makeBow(BowType.RECURVE), ends: [makeEnd(6000, [], 4000)] });
+    const result = checkAllAchievements([practice], [], true);
+    const entry = result.find((r) => r.achievement.id === 'recurve-dedicated')!;
+    expect(entry.isUnlocked).toBe(true);
+    expect(entry.current).toBe(10000);
   });
 });
 

--- a/services/achievements/checker.ts
+++ b/services/achievements/checker.ts
@@ -35,7 +35,7 @@ export function calculateUserStats(practices: Practice[]): UserStats {
     let practiceArrows = 0;
 
     if (practice.ends && Array.isArray(practice.ends)) {
-      practiceArrows = practice.ends.reduce((sum, end) => sum + (end.arrows ?? 0), 0);
+      practiceArrows = practice.ends.reduce((sum, end) => sum + (end.arrows ?? 0) + (end.arrowsWithoutScore ?? 0), 0);
       stats.totalArrows += practiceArrows;
     }
 
@@ -143,7 +143,7 @@ function checkRequirement(
       break;
 
     case 'ARROWS_IN_SESSION': {
-      current = Math.max(...practices.map((p) => p.ends?.reduce((sum, end) => sum + (end.arrows ?? 0), 0) || 0), 0);
+      current = Math.max(...practices.map((p) => p.ends?.reduce((sum, end) => sum + (end.arrows ?? 0) + (end.arrowsWithoutScore ?? 0), 0) || 0), 0);
       required = value as number;
       isMet = compareValues(current, required, comparator);
       break;


### PR DESCRIPTION
## Summary
- **Stats summary stale after mutations**: `handlePracticesSaved` only refreshed the practices list but never re-fetched stats, so `StatsSummary` showed stale data after creating, editing, or deleting a practice or competition. Now calls `loadData()` to refresh stats from the API.
- **Achievements undercounting arrows**: Arrow-based achievements (`ARROW_COUNT`, `ARROWS_IN_SESSION`, `BOW_TYPE_ARROWS`) only counted `end.arrows` (scored) and ignored `end.arrowsWithoutScore`, preventing users who shot unscored arrows from earning those achievements.

## Test plan
- [x] Existing 510 tests pass (including 6 new tests for unscored arrow counting)
- [ ] Create a practice with unscored arrows → verify stats summary updates immediately
- [ ] Edit a practice → verify stats summary reflects the change
- [ ] Delete a practice → verify stats summary updates
- [ ] Verify arrow-based achievements progress includes unscored arrows

🤖 Generated with [Claude Code](https://claude.com/claude-code)