### PR TITLE
fix: remove Vipps button and improve sight marks UX

### DIFF
--- a/components/settings/SettingsStyles.ts
+++ b/components/settings/SettingsStyles.ts
@@ -241,11 +241,6 @@ export const styles = StyleSheet.create({
     fontWeight: '800',
     color: '#ff5b24',
   },
-  vippsButton: {
-    minHeight: 48,
-    width: '100%',
-    borderRadius: 12,
-  },
   // ── Logout ─────────────────────────────────────────────────────────────────
   logoutButton: {
     minHeight: 52,

--- a/components/settings/SupportCard.tsx
+++ b/components/settings/SupportCard.tsx
@@ -1,5 +1,4 @@
-import { Linking, Platform, Text, View } from 'react-native';
-import { Button } from '@/components/common';
+import { Text, View } from 'react-native';
 import { styles } from '@/components/settings/SettingsStyles';
 import { useTranslation } from '@/contexts';
 
@@ -7,13 +6,6 @@ const VIPPS_NUMBER = '44294';
 
 export default function SupportCard() {
   const { t } = useTranslation();
-
-  function handleOpenVipps() {
-    const url = Platform.OS === 'ios' ? `vipps://qr/28/2/01/031/${VIPPS_NUMBER}` : `https://qr.vipps.no/28/2/01/031/${VIPPS_NUMBER}`;
-    Linking.openURL(url).catch(() => {
-      Linking.openURL('https://vipps.no');
-    });
-  }
 
   return (
     <View style={styles.supportContent}>
@@ -23,7 +15,6 @@ export default function SupportCard() {
         <Text style={styles.vippsLabel}>{t['settings.vippsLabel']}</Text>
         <Text style={styles.vippsNumber}>{VIPPS_NUMBER}</Text>
       </View>
-      <Button label={t['settings.vippsButton']} onPress={handleOpenVipps} buttonStyle={styles.vippsButton} />
     </View>
   );
 }

--- a/components/sightMarks/equipmentModal/EquipmentModal.tsx
+++ b/components/sightMarks/equipmentModal/EquipmentModal.tsx
@@ -56,15 +56,40 @@ export default function EquipmentModal({ visible, onClose }: Props) {
       if (bow) {
         updates.push(
           bowRepository.update(bow.id, {
-            eyeToNock: eyeToNock ? parseFloat(eyeToNock) : undefined,
-            eyeToSight: eyeToSight ? parseFloat(eyeToSight) : undefined,
-            aimMeasure: aimMeasure ? parseFloat(aimMeasure) : undefined,
+            name: bow.name,
+            type: bow.type,
+            eyeToNock: eyeToNock ? parseFloat(eyeToNock) : null,
+            aimMeasure: aimMeasure ? parseFloat(aimMeasure) : null,
+            eyeToSight: eyeToSight ? parseFloat(eyeToSight) : null,
+            limbs: bow.limbs ?? undefined,
+            riser: bow.riser ?? undefined,
+            handOrientation: bow.handOrientation,
+            drawWeight: bow.drawWeight ?? undefined,
+            bowLength: bow.bowLength ?? undefined,
+            notes: bow.notes ?? undefined,
+            isFavorite: bow.isFavorite,
           }),
         );
       }
 
       if (arrows) {
-        updates.push(arrowsRepository.update(arrows.id, { weight: arrowWeight ? parseFloat(arrowWeight) : undefined }));
+        updates.push(
+          arrowsRepository.update(arrows.id, {
+            name: arrows.name,
+            material: arrows.material,
+            weight: arrowWeight ? parseFloat(arrowWeight) : null,
+            arrowsCount: arrows.arrowsCount ?? undefined,
+            diameter: arrows.diameter ?? undefined,
+            length: arrows.length ?? undefined,
+            spine: arrows.spine ?? undefined,
+            pointType: arrows.pointType ?? undefined,
+            pointWeight: arrows.pointWeight ?? undefined,
+            vanes: arrows.vanes ?? undefined,
+            nock: arrows.nock ?? undefined,
+            notes: arrows.notes ?? undefined,
+            isFavorite: arrows.isFavorite,
+          }),
+        );
       }
 
       await Promise.all(updates);

--- a/components/sightMarks/equipmentModal/EquipmentModal.tsx
+++ b/components/sightMarks/equipmentModal/EquipmentModal.tsx
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Keyboard, KeyboardAvoidingView, Platform, ScrollView, Text, View } from 'react-native';
+import { Button, Input, ModalHeader, ModalWrapper } from '@/components/common';
+import { Arrows, Bow } from '@/types';
+import { arrowsRepository, bowRepository } from '@/services/repositories';
+import { useTranslation } from '@/contexts';
+import * as Sentry from '@sentry/react-native';
+import { styles } from './EquipmentModalStyles';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export default function EquipmentModal({ visible, onClose }: Props) {
+  const { t } = useTranslation();
+  const [bow, setBow] = useState<Bow | null>(null);
+  const [arrows, setArrows] = useState<Arrows | null>(null);
+  const [eyeToNock, setEyeToNock] = useState('');
+  const [eyeToSight, setEyeToSight] = useState('');
+  const [aimMeasure, setAimMeasure] = useState('');
+  const [arrowWeight, setArrowWeight] = useState('');
+  const [status, setStatus] = useState<'idle' | 'pending'>('idle');
+
+  const loadEquipment = useCallback(async () => {
+    try {
+      const [bows, arrowSets] = await Promise.all([bowRepository.getAll(), arrowsRepository.getAll()]);
+      const favBow = (Array.isArray(bows) ? bows : []).find((b) => b.isFavorite) ?? bows[0] ?? null;
+      const favArrows = (Array.isArray(arrowSets) ? arrowSets : []).find((a) => a.isFavorite) ?? arrowSets[0] ?? null;
+      setBow(favBow);
+      setArrows(favArrows);
+      setEyeToNock(favBow?.eyeToNock?.toString() ?? '');
+      setEyeToSight(favBow?.eyeToSight?.toString() ?? '');
+      setAimMeasure(favBow?.aimMeasure?.toString() ?? '');
+      setArrowWeight(favArrows?.weight?.toString() ?? '');
+    } catch (err) {
+      Sentry.captureException(err);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (visible) loadEquipment();
+  }, [visible, loadEquipment]);
+
+  function handleNumberInput(value: string, setter: (v: string) => void) {
+    const cleaned = value.replace(',', '.').replace(/[^0-9.]/g, '');
+    setter(cleaned);
+  }
+
+  async function handleSave() {
+    try {
+      setStatus('pending');
+      Keyboard.dismiss();
+      const updates: Promise<any>[] = [];
+
+      if (bow) {
+        updates.push(
+          bowRepository.update(bow.id, {
+            eyeToNock: eyeToNock ? parseFloat(eyeToNock) : undefined,
+            eyeToSight: eyeToSight ? parseFloat(eyeToSight) : undefined,
+            aimMeasure: aimMeasure ? parseFloat(aimMeasure) : undefined,
+          }),
+        );
+      }
+
+      if (arrows) {
+        updates.push(arrowsRepository.update(arrows.id, { weight: arrowWeight ? parseFloat(arrowWeight) : undefined }));
+      }
+
+      await Promise.all(updates);
+      onClose();
+    } catch (err) {
+      Sentry.captureException(err);
+    } finally {
+      setStatus('idle');
+    }
+  }
+
+  return (
+    <ModalWrapper visible={visible} onClose={onClose}>
+      <KeyboardAvoidingView
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : undefined}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+        <ScrollView style={styles.modal} keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false} bounces={false}>
+          <ModalHeader onPress={onClose} title={t['sightMarks.equipmentTitle']} />
+
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>{bow?.name ?? t['sightMarks.unknownBow']}</Text>
+            <View style={styles.row}>
+              <Input
+                containerStyle={{ flex: 1 }}
+                label={t['bowForm.eyeToNock']}
+                keyboardType="numeric"
+                value={eyeToNock}
+                onChangeText={(v) => handleNumberInput(v, setEyeToNock)}
+              />
+              <Input
+                containerStyle={{ flex: 1 }}
+                label={t['bowForm.eyeToSight']}
+                keyboardType="numeric"
+                value={eyeToSight}
+                onChangeText={(v) => handleNumberInput(v, setEyeToSight)}
+              />
+            </View>
+            <Input
+              label={t['bowDetails.aimMeasure']}
+              keyboardType="numeric"
+              value={aimMeasure}
+              onChangeText={(v) => handleNumberInput(v, setAimMeasure)}
+            />
+          </View>
+
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>{arrows?.name ?? t['sightMarks.equipmentArrows']}</Text>
+            <Input
+              label={t['arrowDetails.weight']}
+              keyboardType="numeric"
+              value={arrowWeight}
+              helpText={t['arrowForm.weightHelpText']}
+              onChangeText={(v) => handleNumberInput(v, setArrowWeight)}
+            />
+          </View>
+
+          <View style={styles.buttons}>
+            <Button loading={status === 'pending'} buttonStyle={{ flex: 1 }} label={t['form.save']} onPress={handleSave} />
+            <Button type="outline" buttonStyle={{ flex: 1 }} label={t['common.cancel']} onPress={onClose} />
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </ModalWrapper>
+  );
+}

--- a/components/sightMarks/equipmentModal/EquipmentModalStyles.ts
+++ b/components/sightMarks/equipmentModal/EquipmentModalStyles.ts
@@ -1,0 +1,29 @@
+import { StyleSheet } from 'react-native';
+import { colors } from '@/styles/colors';
+
+export const styles = StyleSheet.create({
+  modal: {
+    padding: 24,
+    backgroundColor: colors.white,
+    borderRadius: 12,
+  },
+  section: {
+    marginTop: 16,
+    gap: 4,
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.textSecondary,
+    marginBottom: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  buttons: {
+    flexDirection: 'row',
+    marginTop: 20,
+    gap: 8,
+  },
+});

--- a/components/sightMarks/marksForm/MarksForm.tsx
+++ b/components/sightMarks/marksForm/MarksForm.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useEffect, useRef, useState } from 'react';
 import { Keyboard, Platform, TextInput, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Button, Input, Notch } from '@/components/common';
 import { MarkValue } from '@/types';
 import { faRulerHorizontal } from '@fortawesome/free-solid-svg-icons/faRulerHorizontal';
@@ -23,6 +24,7 @@ interface MarksFormProps {
 
 const MarksForm: FC<MarksFormProps> = ({ sendMarks, status, setIsFormVisible, translateY, isNewSet = false }) => {
   const { t } = useTranslation();
+  const insets = useSafeAreaInsets();
   const [aimValue, setAimValue] = useState('');
   const [distanceValue, setDistance] = useState('');
   const [nameValue, setNameValue] = useState('');
@@ -59,7 +61,8 @@ const MarksForm: FC<MarksFormProps> = ({ sendMarks, status, setIsFormVisible, tr
     const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
 
     const showSub = Keyboard.addListener(showEvent, (e) => {
-      keyboardHeight.value = withTiming(e.endCoordinates.height, {
+      const height = Platform.OS === 'android' ? e.endCoordinates.height + insets.bottom : e.endCoordinates.height;
+      keyboardHeight.value = withTiming(height, {
         duration: Platform.OS === 'ios' ? (e.duration ?? 250) : 200,
       });
     });

--- a/components/sightMarks/screens/CalculateScreen.tsx
+++ b/components/sightMarks/screens/CalculateScreen.tsx
@@ -256,7 +256,7 @@ export default function CalculateScreen() {
         </ScrollView>
       </Pressable>
 
-      <View style={[styles.bottomBar, { paddingBottom: insets.bottom + 80 }]}>
+      <View style={[styles.bottomBar, { bottom: insets.bottom + 80 }]}>
         <Button
           icon={<FontAwesomeIcon icon={faPlus} color={colors.tertiary} />}
           iconPosition="left"
@@ -283,7 +283,7 @@ export default function CalculateScreen() {
 
 const styles = StyleSheet.create({
   page: { flex: 1 },
-  list: { paddingHorizontal: 12, paddingTop: 12, paddingBottom: 80 },
-  bottomBar: { paddingHorizontal: 16, paddingTop: 8 },
+  list: { paddingHorizontal: 12, paddingTop: 12, paddingBottom: 160 },
+  bottomBar: { position: 'absolute', left: 0, right: 0, paddingHorizontal: 16, paddingTop: 8, paddingBottom: 12 },
   newSetButton: { width: '100%' },
 });

--- a/components/sightMarks/screens/MarksScreen.tsx
+++ b/components/sightMarks/screens/MarksScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ScrollView, Text, View } from 'react-native';
+import { Pressable, ScrollView, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Sentry from '@sentry/react-native';
 import { Button, Message, Select } from '@/components/common';
@@ -7,6 +7,7 @@ import { CalculatedMarks, MarksResult, SightMark, SightMarkResult } from '@/type
 import { CalculateMarksModal } from '@/components/sightMarks/calculateMarksModal/CalculateMarksModal';
 import CalculatedMarksTable from '@/components/sightMarks/calculatedMarksTable/CalculatedMarksTable';
 // import { faChartLine } from '@fortawesome/free-solid-svg-icons/faChartLine';
+import { faChevronDown } from '@fortawesome/free-solid-svg-icons/faChevronDown';
 import { faSliders } from '@fortawesome/free-solid-svg-icons/faSliders';
 import { faWind } from '@fortawesome/free-solid-svg-icons/faWind';
 import { faRotateRight } from '@fortawesome/free-solid-svg-icons/faRotateRight';
@@ -37,6 +38,7 @@ export default function MarksScreen({ setScreen }: MarksScreenProps) {
   const [activeSightMark, setActiveSightMark] = useState<SightMark | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
   const [equipmentVisible, setEquipmentVisible] = useState(false);
+  const [cardExpanded, setCardExpanded] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
   const sightMarkOptions = useMemo(
@@ -198,34 +200,55 @@ export default function MarksScreen({ setScreen }: MarksScreenProps) {
       <ScrollView style={styles.scrollView}>
         {sightMarkOptions.length > 0 && (
           <View style={styles.selectorCard}>
-            <Text style={styles.selectorTitle}>{t['sightMarks.selectSet']}</Text>
-            <Text style={styles.selectorHint}>{t['sightMarks.selectSetHint']}</Text>
-            {sightMarkOptions.length > 1 && (
-              <Select
-                label=""
-                options={sightMarkOptions}
-                selectedValue={activeSightMark?.id}
-                onValueChange={handleSetChange}
-                zIndex={2000}
-              />
-            )}
-            {activeSightMark && (
-              <View style={styles.selectorMeta}>
-                <Text style={styles.selectorMetaText}>
-                  {activeSightMark.bow?.name ?? t['sightMarks.unknownBow']}
-                  {' · '}
-                  {activeSightMark.givenDistances.length} {t['sightMarks.markCount']}
-                </Text>
+            <Pressable style={styles.selectorHeader} onPress={() => setCardExpanded(!cardExpanded)}>
+              <View style={styles.selectorHeaderText}>
+                <Text style={styles.selectorTitle}>{t['sightMarks.selectSet']}</Text>
+                {!cardExpanded && activeSightMark && (
+                  <Text style={styles.selectorMetaText}>
+                    {activeSightMark.bow?.name ?? t['sightMarks.unknownBow']}
+                    {' · '}
+                    {activeSightMark.givenDistances.length} {t['sightMarks.markCount']}
+                  </Text>
+                )}
               </View>
+              <FontAwesomeIcon
+                icon={faChevronDown}
+                size={12}
+                color={colors.textSecondary}
+                style={{ transform: [{ rotate: cardExpanded ? '180deg' : '0deg' }] }}
+              />
+            </Pressable>
+            {cardExpanded && (
+              <>
+                <Text style={styles.selectorHint}>{t['sightMarks.selectSetHint']}</Text>
+                {sightMarkOptions.length > 1 && (
+                  <Select
+                    label=""
+                    options={sightMarkOptions}
+                    selectedValue={activeSightMark?.id}
+                    onValueChange={handleSetChange}
+                    zIndex={2000}
+                  />
+                )}
+                {activeSightMark && (
+                  <View style={styles.selectorMeta}>
+                    <Text style={styles.selectorMetaText}>
+                      {activeSightMark.bow?.name ?? t['sightMarks.unknownBow']}
+                      {' · '}
+                      {activeSightMark.givenDistances.length} {t['sightMarks.markCount']}
+                    </Text>
+                  </View>
+                )}
+                <Button
+                  type="outline"
+                  size="small"
+                  iconPosition="left"
+                  icon={<FontAwesomeIcon icon={faSliders} size={14} color={colors.primary} />}
+                  label={t['sightMarks.equipmentButton']}
+                  onPress={() => setEquipmentVisible(true)}
+                />
+              </>
             )}
-            <Button
-              type="outline"
-              size="small"
-              iconPosition="left"
-              icon={<FontAwesomeIcon icon={faSliders} size={14} color={colors.primary} />}
-              label={t['sightMarks.equipmentButton']}
-              onPress={() => setEquipmentVisible(true)}
-            />
           </View>
         )}
         {renderContent()}
@@ -233,7 +256,7 @@ export default function MarksScreen({ setScreen }: MarksScreenProps) {
       {/* )} */}
 
       {calculatedMarks && (
-        <View style={[styles.actionBar, { paddingBottom: insets.bottom + 80 }]}>
+        <View style={[styles.actionBar, { paddingBottom: insets.bottom + 100 }]}>
           <View style={styles.buttons}>
             <Button
               type="outline"

--- a/components/sightMarks/screens/MarksScreen.tsx
+++ b/components/sightMarks/screens/MarksScreen.tsx
@@ -7,6 +7,7 @@ import { CalculatedMarks, MarksResult, SightMark, SightMarkResult } from '@/type
 import { CalculateMarksModal } from '@/components/sightMarks/calculateMarksModal/CalculateMarksModal';
 import CalculatedMarksTable from '@/components/sightMarks/calculatedMarksTable/CalculatedMarksTable';
 // import { faChartLine } from '@fortawesome/free-solid-svg-icons/faChartLine';
+import { faSliders } from '@fortawesome/free-solid-svg-icons/faSliders';
 import { faWind } from '@fortawesome/free-solid-svg-icons/faWind';
 import { faRotateRight } from '@fortawesome/free-solid-svg-icons/faRotateRight';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
@@ -18,6 +19,7 @@ import { sightMarksRepository } from '@/services/repositories';
 import { offlineMutation } from '@/services/offline/mutationHelper';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTranslation } from '@/contexts';
+import EquipmentModal from '@/components/sightMarks/equipmentModal/EquipmentModal';
 
 interface MarksScreenProps {
   setScreen: (screen: string) => void;
@@ -34,6 +36,7 @@ export default function MarksScreen({ setScreen }: MarksScreenProps) {
   const [calculatedMarks, setCalculatedMarks] = useState<MarksResult | null>(null);
   const [activeSightMark, setActiveSightMark] = useState<SightMark | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
+  const [equipmentVisible, setEquipmentVisible] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
   const sightMarkOptions = useMemo(
@@ -215,6 +218,14 @@ export default function MarksScreen({ setScreen }: MarksScreenProps) {
                 </Text>
               </View>
             )}
+            <Button
+              type="outline"
+              size="small"
+              iconPosition="left"
+              icon={<FontAwesomeIcon icon={faSliders} size={14} color={colors.primary} />}
+              label={t['sightMarks.equipmentButton']}
+              onPress={() => setEquipmentVisible(true)}
+            />
           </View>
         )}
         {renderContent()}
@@ -264,6 +275,8 @@ export default function MarksScreen({ setScreen }: MarksScreenProps) {
         sightMarkId={activeSightMark?.id ?? null}
         onResultCreated={() => loadData()}
       />
+
+      <EquipmentModal visible={equipmentVisible} onClose={() => setEquipmentVisible(false)} />
     </View>
   );
 }

--- a/components/sightMarks/screens/MarksScreen.tsx
+++ b/components/sightMarks/screens/MarksScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ScrollView, View } from 'react-native';
+import { ScrollView, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Sentry from '@sentry/react-native';
 import { Button, Message, Select } from '@/components/common';
@@ -193,15 +193,28 @@ export default function MarksScreen({ setScreen }: MarksScreenProps) {
         <ChartScreen calculatedMarks={calculatedMarks} marks={ballistics} setModalVisible={setModalVisible} />
       ) : ( */}
       <ScrollView style={styles.scrollView}>
-        {sightMarkOptions.length > 1 && (
-          <View style={styles.selectorContainer}>
-            <Select
-              label={t['sightMarks.selectSet']}
-              options={sightMarkOptions}
-              selectedValue={activeSightMark?.id}
-              onValueChange={handleSetChange}
-              zIndex={2000}
-            />
+        {sightMarkOptions.length > 0 && (
+          <View style={styles.selectorCard}>
+            <Text style={styles.selectorTitle}>{t['sightMarks.selectSet']}</Text>
+            <Text style={styles.selectorHint}>{t['sightMarks.selectSetHint']}</Text>
+            {sightMarkOptions.length > 1 && (
+              <Select
+                label=""
+                options={sightMarkOptions}
+                selectedValue={activeSightMark?.id}
+                onValueChange={handleSetChange}
+                zIndex={2000}
+              />
+            )}
+            {activeSightMark && (
+              <View style={styles.selectorMeta}>
+                <Text style={styles.selectorMetaText}>
+                  {activeSightMark.bow?.name ?? t['sightMarks.unknownBow']}
+                  {' · '}
+                  {activeSightMark.givenDistances.length} {t['sightMarks.markCount']}
+                </Text>
+              </View>
+            )}
           </View>
         )}
         {renderContent()}

--- a/components/sightMarks/screens/MarksScreenStyles.ts
+++ b/components/sightMarks/screens/MarksScreenStyles.ts
@@ -1,4 +1,5 @@
 import { StyleSheet } from 'react-native';
+import { colors } from '@/styles/colors';
 
 export const styles = StyleSheet.create({
   page: {
@@ -8,10 +9,36 @@ export const styles = StyleSheet.create({
     flex: 1,
     minHeight: '50%',
   },
-  selectorContainer: {
-    paddingHorizontal: 16,
-    paddingTop: 12,
+  selectorCard: {
+    marginHorizontal: 16,
+    marginTop: 12,
+    padding: 16,
+    backgroundColor: colors.white,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
     zIndex: 2000,
+    gap: 8,
+  },
+  selectorTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.primary,
+  },
+  selectorHint: {
+    fontSize: 13,
+    color: colors.textSecondary,
+    lineHeight: 18,
+  },
+  selectorMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    marginTop: 4,
+  },
+  selectorMetaText: {
+    fontSize: 13,
+    color: colors.textSecondary,
   },
   emptyState: {
     marginTop: 'auto',

--- a/components/sightMarks/screens/MarksScreenStyles.ts
+++ b/components/sightMarks/screens/MarksScreenStyles.ts
@@ -20,6 +20,15 @@ export const styles = StyleSheet.create({
     zIndex: 2000,
     gap: 8,
   },
+  selectorHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  selectorHeaderText: {
+    flex: 1,
+    gap: 2,
+  },
   selectorTitle: {
     fontSize: 16,
     fontWeight: '700',
@@ -46,8 +55,8 @@ export const styles = StyleSheet.create({
   },
   actionBar: {
     paddingHorizontal: 16,
-    paddingTop: 8,
-    paddingBottom: 16,
+    paddingTop: 16,
+    paddingBottom: 24,
     gap: 8,
   },
   buttons: {

--- a/lib/i18n/translations/en.ts
+++ b/lib/i18n/translations/en.ts
@@ -496,6 +496,9 @@ export const en: TranslationKeys = {
   'sightMarks.selectSetHint': 'Choose which calibration set to use as the basis for calculation.',
   'sightMarks.markCount': 'marks',
   'sightMarks.unknownBow': 'Unknown bow',
+  'sightMarks.equipmentTitle': 'Equipment settings',
+  'sightMarks.equipmentArrows': 'Arrows',
+  'sightMarks.equipmentButton': 'Equipment',
 
   'calcMarks.fromDistance': 'From distance',
   'calcMarks.toDistance': 'To distance',

--- a/lib/i18n/translations/en.ts
+++ b/lib/i18n/translations/en.ts
@@ -493,6 +493,9 @@ export const en: TranslationKeys = {
   'sightMarks.showSpeed': 'Show speeds',
   'sightMarks.recalculate': 'Recalculate',
   'sightMarks.selectSet': 'Select sighting',
+  'sightMarks.selectSetHint': 'Choose which calibration set to use as the basis for calculation.',
+  'sightMarks.markCount': 'marks',
+  'sightMarks.unknownBow': 'Unknown bow',
 
   'calcMarks.fromDistance': 'From distance',
   'calcMarks.toDistance': 'To distance',

--- a/lib/i18n/translations/en.ts
+++ b/lib/i18n/translations/en.ts
@@ -592,7 +592,6 @@ export const en: TranslationKeys = {
   'settings.supportTitle': 'Support the project',
   'settings.supportDesc': 'Bueboka is developed and maintained by volunteers. All contributions go directly to operations and further development.',
   'settings.vippsLabel': 'Vipps number',
-  'settings.vippsButton': 'Open Vipps',
 
   // Bow form
   'bowForm.editTitle': 'Edit bow',

--- a/lib/i18n/translations/no.ts
+++ b/lib/i18n/translations/no.ts
@@ -493,6 +493,9 @@ export const no: TranslationKeys = {
   'sightMarks.showSpeed': 'Vis hastigheter',
   'sightMarks.recalculate': 'Beregn på nytt',
   'sightMarks.selectSet': 'Velg innskyting',
+  'sightMarks.selectSetHint': 'Velg hvilket sett med innskytingsmerker som skal brukes som grunnlag for beregningen.',
+  'sightMarks.markCount': 'merker',
+  'sightMarks.unknownBow': 'Ukjent bue',
 
   'calcMarks.fromDistance': 'Fra avstand',
   'calcMarks.toDistance': 'Til avstand',

--- a/lib/i18n/translations/no.ts
+++ b/lib/i18n/translations/no.ts
@@ -592,7 +592,6 @@ export const no: TranslationKeys = {
   'settings.supportTitle': 'Støtt prosjektet',
   'settings.supportDesc': 'Bueboka utvikles og driftes av frivillige på dugnad. Alle bidrag går direkte til drift og videreutvikling.',
   'settings.vippsLabel': 'Vipps-nummer',
-  'settings.vippsButton': 'Åpne Vipps',
 
   // Bow form
   'bowForm.editTitle': 'Rediger bue',

--- a/lib/i18n/translations/no.ts
+++ b/lib/i18n/translations/no.ts
@@ -496,6 +496,9 @@ export const no: TranslationKeys = {
   'sightMarks.selectSetHint': 'Velg hvilket sett med innskytingsmerker som skal brukes som grunnlag for beregningen.',
   'sightMarks.markCount': 'merker',
   'sightMarks.unknownBow': 'Ukjent bue',
+  'sightMarks.equipmentTitle': 'Utstyrsinnstillinger',
+  'sightMarks.equipmentArrows': 'Piler',
+  'sightMarks.equipmentButton': 'Utstyr',
 
   'calcMarks.fromDistance': 'Fra avstand',
   'calcMarks.toDistance': 'Til avstand',

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -535,6 +535,9 @@ export interface TranslationKeys {
   'sightMarks.selectSetHint': string;
   'sightMarks.markCount': string;
   'sightMarks.unknownBow': string;
+  'sightMarks.equipmentTitle': string;
+  'sightMarks.equipmentArrows': string;
+  'sightMarks.equipmentButton': string;
 
   // Calculate marks modal
   'calcMarks.fromDistance': string;

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -634,7 +634,6 @@ export interface TranslationKeys {
   'settings.supportTitle': string;
   'settings.supportDesc': string;
   'settings.vippsLabel': string;
-  'settings.vippsButton': string;
 
   // Bow form
   'bowForm.editTitle': string;

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -532,6 +532,9 @@ export interface TranslationKeys {
   'sightMarks.showSpeed': string;
   'sightMarks.recalculate': string;
   'sightMarks.selectSet': string;
+  'sightMarks.selectSetHint': string;
+  'sightMarks.markCount': string;
+  'sightMarks.unknownBow': string;
 
   // Calculate marks modal
   'calcMarks.fromDistance': string;


### PR DESCRIPTION
## Summary
- Remove the Vipps deep-link button from the support card, keeping the Vipps number as plain text
- Make the CalculateScreen scrollable so users with many sight mark sets can view all of them
- Add a selector card with title, hint, and meta info on the MarksScreen (collapsible to save space)
- Add an equipment settings modal for quick edits to bow measurements and arrow weight without leaving the sight marks context
- Fix Android keyboard offset so the marks form submit button is not hidden behind the keyboard
- Add more spacing between action bar buttons and the tab bar

## Test plan
- [x] All 409 existing tests pass
- [ ] Verify Vipps number still displays correctly in settings
- [ ] Open sight marks tab with multiple calibration sets and confirm scrolling works
- [ ] Expand/collapse the selector card on MarksScreen
- [ ] Open equipment modal, edit values, save, and confirm they persist
- [ ] Test marks form keyboard behavior on both iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)