### PR TITLE
fix(android): stop navigation footer flicker when keyboard opens

### DIFF
--- a/app/auth.tsx
+++ b/app/auth.tsx
@@ -118,7 +118,7 @@ function AuthScreen({ onAuthSuccess }: AuthScreenProps) {
   }
 
   return (
-    <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.container}>
+    <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={styles.container}>
       <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
         <AuthLogo />
         <AuthForm

--- a/components/home/arrowForm/ArrowForm.tsx
+++ b/components/home/arrowForm/ArrowForm.tsx
@@ -168,7 +168,7 @@ export default function ArrowForm({ modalVisible, setArrowModalVisible, arrowSet
         clearForm();
         setArrowModalVisible(false);
       }}>
-      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.modal}>
+      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={styles.modal}>
         <ModalHeader onPress={handleCloseModal} title={arrowSet ? t['arrowForm.editTitle'] : t['arrowForm.newTitle']} />
         <ScrollView keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
           <Pressable onPress={() => Keyboard.dismiss()}>

--- a/components/home/bowForm/BowForm.tsx
+++ b/components/home/bowForm/BowForm.tsx
@@ -155,7 +155,7 @@ const BowForm = ({ modalVisible, setModalVisible, bow, existingBows = [], onSucc
         clearForm();
         setModalVisible(false);
       }}>
-      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.modal}>
+      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={styles.modal}>
         <ModalHeader onPress={handleCloseModal} title={bow ? t['bowForm.editTitle'] : t['bowForm.newTitle']} />
         <ScrollView keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
           <Pressable onPress={() => Keyboard.dismiss()}>

--- a/components/practice/competitionForm/CreateCompetitionForm.tsx
+++ b/components/practice/competitionForm/CreateCompetitionForm.tsx
@@ -546,7 +546,7 @@ export default function CreateCompetitionForm({
   return (
     <ModalWrapper visible={visible} onClose={handleClose} fullScreen>
       <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
-        <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+        <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
           <Pressable onPress={Keyboard.dismiss}>
             <ModalHeader title={isEditing ? t['competitionForm.editTitle'] : t['competitionForm.newTitle']} onPress={handleClose} />
           </Pressable>

--- a/components/practice/practiceForm/CreatePracticeForm.tsx
+++ b/components/practice/practiceForm/CreatePracticeForm.tsx
@@ -436,7 +436,7 @@ export default function CreatePracticeForm({
   return (
     <ModalWrapper visible={visible} onClose={handleClose} fullScreen>
       <View style={[styles.safeArea, { paddingTop: insets.top, paddingBottom: insets.bottom }]}>
-        <KeyboardAvoidingView style={styles.container} behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+        <KeyboardAvoidingView style={styles.container} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
           <Pressable onPress={Keyboard.dismiss}>
             <ModalHeader title={isEditing ? t['practiceForm.editTitle'] : t['practiceForm.newTitle']} onPress={handleClose} />
           </Pressable>

--- a/components/sightMarks/calculateMarksModal/CalculateMarksModal.tsx
+++ b/components/sightMarks/calculateMarksModal/CalculateMarksModal.tsx
@@ -159,7 +159,7 @@ export const CalculateMarksModal = ({
       visible={modalVisible}>
       <KeyboardAvoidingView
         keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : undefined}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
         <ScrollView style={styles.modal} keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false} bounces={false}>
           <ModalHeader onPress={handleCloseModal} title={t['sightMarks.calculateButton']} />
           <View style={styles.inputs}>

--- a/components/sightMarks/equipmentModal/EquipmentModal.tsx
+++ b/components/sightMarks/equipmentModal/EquipmentModal.tsx
@@ -105,7 +105,7 @@ export default function EquipmentModal({ visible, onClose }: Props) {
     <ModalWrapper visible={visible} onClose={onClose}>
       <KeyboardAvoidingView
         keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : undefined}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
         <ScrollView style={styles.modal} keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false} bounces={false}>
           <ModalHeader onPress={onClose} title={t['sightMarks.equipmentTitle']} />
 


### PR DESCRIPTION
## Summary
- Disable `KeyboardAvoidingView` behavior on Android (`undefined` instead of `"height"`) across all 7 forms/modals
- Android's default `adjustResize` already handles keyboard avoidance — the extra `behavior="height"` caused a double-adjustment making footers bounce when typing in inputs

## Test plan
- [ ] Open create practice form on Android, go to Runder step, tap into an input — footer should stay stable
- [ ] Verify same fix on: bow form, arrow form, competition form, sight marks calculate modal, equipment modal, auth screen
- [ ] Verify iOS keyboard avoidance still works correctly (unchanged `padding` behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)