### PR TITLE
Release: Android fixes, equipment modal, nav styling, environment auto-set

### DIFF
--- a/app/auth.tsx
+++ b/app/auth.tsx
@@ -118,7 +118,7 @@ function AuthScreen({ onAuthSuccess }: AuthScreenProps) {
   }
 
   return (
-    <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.container}>
+    <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={styles.container}>
       <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
         <AuthLogo />
         <AuthForm

--- a/components/common/Textarea/TextareaStyles.ts
+++ b/components/common/Textarea/TextareaStyles.ts
@@ -35,7 +35,7 @@ export const defaultStyles = StyleSheet.create({
     backgroundColor: colors.white,
     paddingHorizontal: 12,
     paddingVertical: 12,
-    minHeight: 80,
+    minHeight: 120,
     width: '100%',
     fontSize: 14,
     borderColor: colors.dimmed,

--- a/components/home/arrowForm/ArrowForm.tsx
+++ b/components/home/arrowForm/ArrowForm.tsx
@@ -168,7 +168,7 @@ export default function ArrowForm({ modalVisible, setArrowModalVisible, arrowSet
         clearForm();
         setArrowModalVisible(false);
       }}>
-      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.modal}>
+      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={styles.modal}>
         <ModalHeader onPress={handleCloseModal} title={arrowSet ? t['arrowForm.editTitle'] : t['arrowForm.newTitle']} />
         <ScrollView keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
           <Pressable onPress={() => Keyboard.dismiss()}>

--- a/components/home/bowForm/BowForm.tsx
+++ b/components/home/bowForm/BowForm.tsx
@@ -155,7 +155,7 @@ const BowForm = ({ modalVisible, setModalVisible, bow, existingBows = [], onSucc
         clearForm();
         setModalVisible(false);
       }}>
-      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.modal}>
+      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={styles.modal}>
         <ModalHeader onPress={handleCloseModal} title={bow ? t['bowForm.editTitle'] : t['bowForm.newTitle']} />
         <ScrollView keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
           <Pressable onPress={() => Keyboard.dismiss()}>

--- a/components/practice/competitionForm/CreateCompetitionForm.tsx
+++ b/components/practice/competitionForm/CreateCompetitionForm.tsx
@@ -236,6 +236,7 @@ export default function CreateCompetitionForm({
   const handleCategoryChange = (cat: PracticeCategory) => {
     setPracticeCategory(cat);
     setRounds([emptyRound(1, cat)]);
+    setEnvironment(cat === PracticeCategory.SKIVE_INDOOR ? Environment.INDOOR : Environment.OUTDOOR);
   };
 
   // ─── Rounds ────────────────────────────────────────────────────────────────

--- a/components/practice/competitionForm/CreateCompetitionForm.tsx
+++ b/components/practice/competitionForm/CreateCompetitionForm.tsx
@@ -546,7 +546,7 @@ export default function CreateCompetitionForm({
   return (
     <ModalWrapper visible={visible} onClose={handleClose} fullScreen>
       <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
-        <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+        <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
           <Pressable onPress={Keyboard.dismiss}>
             <ModalHeader title={isEditing ? t['competitionForm.editTitle'] : t['competitionForm.newTitle']} onPress={handleClose} />
           </Pressable>

--- a/components/practice/practiceForm/CreatePracticeForm.tsx
+++ b/components/practice/practiceForm/CreatePracticeForm.tsx
@@ -436,7 +436,7 @@ export default function CreatePracticeForm({
   return (
     <ModalWrapper visible={visible} onClose={handleClose} fullScreen>
       <View style={[styles.safeArea, { paddingTop: insets.top, paddingBottom: insets.bottom }]}>
-        <KeyboardAvoidingView style={styles.container} behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+        <KeyboardAvoidingView style={styles.container} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
           <Pressable onPress={Keyboard.dismiss}>
             <ModalHeader title={isEditing ? t['practiceForm.editTitle'] : t['practiceForm.newTitle']} onPress={handleClose} />
           </Pressable>

--- a/components/practice/practiceForm/CreatePracticeForm.tsx
+++ b/components/practice/practiceForm/CreatePracticeForm.tsx
@@ -277,6 +277,7 @@ export default function CreatePracticeForm({
   const handleCategoryChange = (cat: PracticeCategory) => {
     setPracticeCategory(cat);
     setRounds([emptyRound(cat)]);
+    setEnvironment(cat === PracticeCategory.SKIVE_INDOOR ? Environment.INDOOR : Environment.OUTDOOR);
   };
 
   // ─── Rounds ──────────────────────────────────────────────────────────────────

--- a/components/practice/shared/NavigationFooter.tsx
+++ b/components/practice/shared/NavigationFooter.tsx
@@ -46,16 +46,16 @@ export function NavigationFooter({
             onPress={onPrev}
             disabled={isFirstStep}
             accessibilityLabel={t['form.prevStep']}>
-            <FontAwesomeIcon icon={faChevronLeft} size={18} color={isFirstStep ? colors.dimmed : colors.primary} />
+            <FontAwesomeIcon icon={faChevronLeft} size={18} color={isFirstStep ? colors.dimmed : colors.white} />
           </TouchableOpacity>
 
           <Text style={styles.navStepName}>{stepLabels[currentStep]}</Text>
 
           {isLastStep ? (
-            <View style={styles.navArrow} />
+            <View style={styles.navArrowSpacer} />
           ) : (
             <TouchableOpacity style={styles.navArrow} onPress={onNext} accessibilityLabel={t['form.nextStep']}>
-              <FontAwesomeIcon icon={faChevronRight} size={18} color={colors.primary} />
+              <FontAwesomeIcon icon={faChevronRight} size={18} color={colors.white} />
             </TouchableOpacity>
           )}
         </View>
@@ -116,7 +116,11 @@ const styles = StyleSheet.create({
     borderRadius: 18,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: colors.bgGray50,
+    backgroundColor: colors.primary,
+  },
+  navArrowSpacer: {
+    width: 36,
+    height: 36,
   },
   navArrowDisabled: {
     opacity: 0.3,

--- a/components/sightMarks/calculateMarksModal/CalculateMarksModal.tsx
+++ b/components/sightMarks/calculateMarksModal/CalculateMarksModal.tsx
@@ -159,7 +159,7 @@ export const CalculateMarksModal = ({
       visible={modalVisible}>
       <KeyboardAvoidingView
         keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : undefined}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
         <ScrollView style={styles.modal} keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false} bounces={false}>
           <ModalHeader onPress={handleCloseModal} title={t['sightMarks.calculateButton']} />
           <View style={styles.inputs}>

--- a/components/sightMarks/equipmentModal/EquipmentModal.tsx
+++ b/components/sightMarks/equipmentModal/EquipmentModal.tsx
@@ -128,7 +128,7 @@ export default function EquipmentModal({ visible, onClose }: Props) {
               />
             </View>
             <Input
-              label={t['bowDetails.aimMeasure']}
+              label={t['sightMarks.equipmentAimMeasure']}
               keyboardType="numeric"
               value={aimMeasure}
               onChangeText={(v) => handleNumberInput(v, setAimMeasure)}
@@ -138,7 +138,7 @@ export default function EquipmentModal({ visible, onClose }: Props) {
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>{arrows?.name ?? t['sightMarks.equipmentArrows']}</Text>
             <Input
-              label={t['arrowDetails.weight']}
+              label={t['sightMarks.equipmentArrowWeight']}
               keyboardType="numeric"
               value={arrowWeight}
               helpText={t['arrowForm.weightHelpText']}

--- a/components/sightMarks/equipmentModal/EquipmentModal.tsx
+++ b/components/sightMarks/equipmentModal/EquipmentModal.tsx
@@ -105,7 +105,7 @@ export default function EquipmentModal({ visible, onClose }: Props) {
     <ModalWrapper visible={visible} onClose={onClose}>
       <KeyboardAvoidingView
         keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : undefined}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
         <ScrollView style={styles.modal} keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false} bounces={false}>
           <ModalHeader onPress={onClose} title={t['sightMarks.equipmentTitle']} />
 

--- a/components/sightMarks/screens/CalculateScreen.tsx
+++ b/components/sightMarks/screens/CalculateScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Keyboard, Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import { Keyboard, Pressable, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { AimDistanceMark, Arrows, Bow, MarkValue, SightMark } from '@/types';
 import { useSharedValue, withTiming } from 'react-native-reanimated';
@@ -12,12 +12,14 @@ import ConfirmRemoveMarks from '@/components/sightMarks/confirmRemoveMarks/Confi
 import { Button, Message } from '@/components/common';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
+import { faSliders } from '@fortawesome/free-solid-svg-icons/faSliders';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { arrowsRepository, bowRepository, sightMarksRepository } from '@/services/repositories';
 import { offlineMutation } from '@/services/offline/mutationHelper';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTranslation } from '@/contexts';
 import { AppError } from '@/services';
+import EquipmentModal from '@/components/sightMarks/equipmentModal/EquipmentModal';
 
 export default function CalculateScreen() {
   const { user } = useAuth();
@@ -33,6 +35,7 @@ export default function CalculateScreen() {
   const [status, setStatus] = useState<'idle' | 'pending' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [equipmentVisible, setEquipmentVisible] = useState(false);
 
   const loadData = useCallback(async () => {
     setIsLoading(true);
@@ -230,6 +233,11 @@ export default function CalculateScreen() {
     <GestureHandlerRootView style={styles.page}>
       <Pressable style={{ flex: 1 }} onPress={Keyboard.dismiss}>
         <ScrollView contentContainerStyle={styles.list}>
+          <TouchableOpacity style={styles.equipmentButton} onPress={() => setEquipmentVisible(true)} activeOpacity={0.7}>
+            <FontAwesomeIcon icon={faSliders} size={13} color={colors.white} />
+            <Text style={styles.equipmentButtonText}>{t['sightMarks.equipmentButton']}</Text>
+          </TouchableOpacity>
+
           {error && (
             <Message
               title={t['sightMarks.errorTitle']}
@@ -277,6 +285,8 @@ export default function CalculateScreen() {
       )}
 
       <ConfirmRemoveMarks modalVisible={confirmDeleteId !== null} onConfirm={handleDeleteSet} closeModal={() => setConfirmDeleteId(null)} />
+
+      <EquipmentModal visible={equipmentVisible} onClose={() => setEquipmentVisible(false)} />
     </GestureHandlerRootView>
   );
 }
@@ -286,4 +296,22 @@ const styles = StyleSheet.create({
   list: { paddingHorizontal: 12, paddingTop: 12, paddingBottom: 160 },
   bottomBar: { position: 'absolute', left: 0, right: 0, paddingHorizontal: 16, paddingTop: 8, paddingBottom: 12 },
   newSetButton: { width: '100%' },
+  equipmentButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-end',
+    gap: 6,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.3)',
+    backgroundColor: 'rgba(255,255,255,0.1)',
+    marginBottom: 8,
+  },
+  equipmentButtonText: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: colors.white,
+  },
 });

--- a/components/sightMarks/screens/MarksScreen.tsx
+++ b/components/sightMarks/screens/MarksScreen.tsx
@@ -8,7 +8,6 @@ import { CalculateMarksModal } from '@/components/sightMarks/calculateMarksModal
 import CalculatedMarksTable from '@/components/sightMarks/calculatedMarksTable/CalculatedMarksTable';
 // import { faChartLine } from '@fortawesome/free-solid-svg-icons/faChartLine';
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons/faChevronDown';
-import { faSliders } from '@fortawesome/free-solid-svg-icons/faSliders';
 import { faWind } from '@fortawesome/free-solid-svg-icons/faWind';
 import { faRotateRight } from '@fortawesome/free-solid-svg-icons/faRotateRight';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
@@ -20,8 +19,6 @@ import { sightMarksRepository } from '@/services/repositories';
 import { offlineMutation } from '@/services/offline/mutationHelper';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTranslation } from '@/contexts';
-import EquipmentModal from '@/components/sightMarks/equipmentModal/EquipmentModal';
-
 interface MarksScreenProps {
   setScreen: (screen: string) => void;
 }
@@ -37,7 +34,6 @@ export default function MarksScreen({ setScreen }: MarksScreenProps) {
   const [calculatedMarks, setCalculatedMarks] = useState<MarksResult | null>(null);
   const [activeSightMark, setActiveSightMark] = useState<SightMark | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
-  const [equipmentVisible, setEquipmentVisible] = useState(false);
   const [cardExpanded, setCardExpanded] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -239,14 +235,6 @@ export default function MarksScreen({ setScreen }: MarksScreenProps) {
                     </Text>
                   </View>
                 )}
-                <Button
-                  type="outline"
-                  size="small"
-                  iconPosition="left"
-                  icon={<FontAwesomeIcon icon={faSliders} size={14} color={colors.primary} />}
-                  label={t['sightMarks.equipmentButton']}
-                  onPress={() => setEquipmentVisible(true)}
-                />
               </>
             )}
           </View>
@@ -299,7 +287,6 @@ export default function MarksScreen({ setScreen }: MarksScreenProps) {
         onResultCreated={() => loadData()}
       />
 
-      <EquipmentModal visible={equipmentVisible} onClose={() => setEquipmentVisible(false)} />
     </View>
   );
 }

--- a/lib/i18n/translations/en.ts
+++ b/lib/i18n/translations/en.ts
@@ -499,6 +499,8 @@ export const en: TranslationKeys = {
   'sightMarks.equipmentTitle': 'Equipment settings',
   'sightMarks.equipmentArrows': 'Arrows',
   'sightMarks.equipmentButton': 'Equipment',
+  'sightMarks.equipmentAimMeasure': 'Measured 5 cm on sight',
+  'sightMarks.equipmentArrowWeight': 'Arrow weight (grams)',
 
   'calcMarks.fromDistance': 'From distance',
   'calcMarks.toDistance': 'To distance',

--- a/lib/i18n/translations/no.ts
+++ b/lib/i18n/translations/no.ts
@@ -499,6 +499,8 @@ export const no: TranslationKeys = {
   'sightMarks.equipmentTitle': 'Utstyrsinnstillinger',
   'sightMarks.equipmentArrows': 'Piler',
   'sightMarks.equipmentButton': 'Utstyr',
+  'sightMarks.equipmentAimMeasure': 'Målt 5 cm på siktet',
+  'sightMarks.equipmentArrowWeight': 'Tyngde pil (gram)',
 
   'calcMarks.fromDistance': 'Fra avstand',
   'calcMarks.toDistance': 'Til avstand',

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -538,6 +538,8 @@ export interface TranslationKeys {
   'sightMarks.equipmentTitle': string;
   'sightMarks.equipmentArrows': string;
   'sightMarks.equipmentButton': string;
+  'sightMarks.equipmentAimMeasure': string;
+  'sightMarks.equipmentArrowWeight': string;
 
   // Calculate marks modal
   'calcMarks.fromDistance': string;


### PR DESCRIPTION
## Summary
- Fix Android keyboard flicker in form modals by disabling KeyboardAvoidingView behavior on Android
- Move equipment modal from Siktemerker to Innskyting tab with clarified labels
- Style navigation arrows with primary color background for better visibility
- Increase textarea min height for notes field
- Auto-set environment to outdoor when selecting outdoor/felt/jakt categories

## Test plan
- [ ] Verify no keyboard flicker on Android in practice/competition forms
- [ ] Verify equipment modal opens from Innskyting tab
- [ ] Verify nav arrows are styled with primary color
- [ ] Verify environment auto-sets when changing practice category

🤖 Generated with [Claude Code](https://claude.com/claude-code)