### PR TITLE
chore: bump version to 2.0.1

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
     },
     "name": "Bueboka",
     "slug": "bueboka",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "icon": "./assets/images/icon.png",
     "extra": {
       "eas": {
@@ -33,7 +33,7 @@
         "backgroundColor": "#29B6F6"
       },
       "infoPlist": {
-        "CFBundleShortVersionString": "2.0.0",
+        "CFBundleShortVersionString": "2.0.1",
         "CFBundleIconName": "./assets/images/ipad.png",
         "ITSAppUsesNonExemptEncryption": false,
         "NSPhotoLibraryUsageDescription": "Bueboka trenger tilgang til bilder for at du skal kunne velge profilbilde.",


### PR DESCRIPTION
## Summary
- Bumps app version from 2.0.0 to 2.0.1 in `app.json` (both `version` and `CFBundleShortVersionString`)

## Test plan
- [x] All 43 test suites pass (409 tests)
- [ ] Verify EAS build picks up the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)